### PR TITLE
Widen visual-only river channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install
 npm run dev
 ```
 
-`npm run dev` first bakes manifest v9 into `public/world/`, then starts Vite. Use `npm run build` for a production build and `npm test` for generated-data plus Dawn-backed shader validation.
+`npm run dev` first bakes manifest v10 into `public/world/`, then starts Vite. Use `npm run build` for a production build and `npm test` for generated-data plus Dawn-backed shader validation.
 
 With the dev server running, `npm run visual-check` launches Chrome through Playwright and writes world, mountain, city, lake-road, and diagnostic captures plus `artifacts/visual-report.json`. On Windows it defaults to a short-lived headed browser because Chrome headless does not reliably expose the hardware WebGPU adapter. Set `IRONFRONTS_BROWSER` to select another Chromium executable or `IRONFRONTS_HEADLESS=true` when a CI GPU adapter is available.
 
@@ -41,9 +41,9 @@ The compact `world.json` contains only runtime-critical province hover data. Pop
 
 ## Rendering
 
-Terrain materials blend by gameplay terrain, biome, slope, and macro variation. Beach sand is restricted to the actual shoreline mask, while low inland regions retain their biome. Forest ground transitions to a cheap canopy-green signal as individual trees fade. A signed-distance bank field smooths ocean, lake, and visual-river edges without blurring narrow channels closed. Ocean and lake water combines slowly varying directional wave packets, domain-warped wind ripples, broken shoreline foam, Fresnel reflection, and sun sparkle.
+Terrain materials blend by gameplay terrain, biome, slope, and macro variation. Beach sand is restricted to the actual shoreline mask, while low inland regions retain their biome. Forest ground transitions to a cheap canopy-green signal as individual trees fade. A signed-distance bank field smooths ocean, lake, and visual-river edges without blurring narrow channels closed. Visual-only one- and two-texel river channels are expanded to a strategy-readable 7.6-unit minimum in a presentation-only mask, while movement rivers keep their independent 11-unit minimum and graph semantics. Ocean and lake water combines slowly varying directional wave packets, domain-warped wind ripples, broken shoreline foam, Fresnel reflection, and sun sparkle.
 
-Supplied rivers are densely resampled into explicit ribbons with an eleven-unit minimum readable width, smoothed bank-width transitions, and a conservative terrain-clipping overlap. Each vertex carries a downhill tangent and locally varied speed. The shader advects several warped noise layers along that flow, slows current near banks, and produces broken streaks instead of circular ripples or uniform texture scrolling. The two authored canals remain in diagnostics but use the province-zero ocean-water channels directly, avoiding duplicate ribbons or offshore caps.
+Supplied movement rivers are densely resampled into explicit ribbons with an eleven-unit minimum readable width, smoothed bank-width transitions, and a conservative terrain-clipping overlap. Each vertex carries a downhill tangent and locally varied speed. The shader advects several warped noise layers along that flow, slows current near banks, and produces broken streaks instead of circular ripples or uniform texture scrolling. The two authored canals remain in diagnostics but use the province-zero ocean-water channels directly, avoiding duplicate ribbons or offshore caps.
 
 There is one road type in this milestone: a narrow dirt path. Each unique land-adjacent province pair receives one independent path between its two province centers. There are no infrastructure levels, importance classes, shared corridors, shared stems, gateway roads, plazas, or emitted local city streets. The two-channel strategic road field stores only core and verge coverage. Full-width route audits reject static-water incursions, and every road vertex independently samples the frozen terrain with a small deterministic lift.
 

--- a/scripts/build-world.mjs
+++ b/scripts/build-world.mjs
@@ -8,6 +8,7 @@ import { buildInstances } from './world/instances.mjs';
 import { generateTopography } from './world/topography.mjs';
 import { buildBankField } from './world/water-fields.mjs';
 import { buildWaterways } from './world/waterways.mjs';
+import { buildVisualRiverField } from './world/visual-rivers.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const MATERIAL = path.join(ROOT, 'material');
@@ -232,6 +233,16 @@ async function main() {
     networkData, connectionData, provinceIds, idWidth: ID_WIDTH, idHeight: ID_HEIGHT, heights,
     heightWidth: FIELD_WIDTH, heightHeight: FIELD_HEIGHT, worldWidth: WORLD_WIDTH, worldHeight: WORLD_HEIGHT,
   });
+  console.log('Expanding narrow visual-only river channels...');
+  const visualRivers = buildVisualRiverField({
+    provinceIds, movementMask: waterways.mask, networkData, connectionData, width: ID_WIDTH, height: ID_HEIGHT,
+    worldWidth: WORLD_WIDTH, worldHeight: WORLD_HEIGHT,
+  });
+  const waterwayField = new Uint8Array(ID_WIDTH * ID_HEIGHT * 2);
+  for (let index = 0; index < provinceIds.length; index += 1) {
+    waterwayField[index * 2] = waterways.mask[index];
+    waterwayField[index * 2 + 1] = visualRivers.mask[index];
+  }
   console.log('Compiling direct province-center roads and city placement...');
   const infrastructure = buildInfrastructure({
     borderData, connectionData, networkData, provinces: metadata.provinces, heights, landField,
@@ -240,7 +251,7 @@ async function main() {
   });
   const placementClearance = infrastructure.roadClearance.slice();
   for (let index = 0; index < placementClearance.length; index += 1) {
-    placementClearance[index] = Math.max(placementClearance[index], waterways.clearance[index]);
+    placementClearance[index] = Math.max(placementClearance[index], waterways.clearance[index], visualRivers.clearance[index]);
   }
   const { trees, buildings } = buildInstances(metadata.provinces, geometryById, provinceIds, areaCounts, placementClearance, infrastructure.cityPlans);
 
@@ -265,15 +276,16 @@ async function main() {
   for (const height of heights) maxHeight = Math.max(maxHeight, height);
 
   const worldGenerationReport = {
-    version: 'world-generation-v9',
+    version: 'world-generation-v10',
     topography: topographyReport,
     banks: bankField.report,
     waterways: waterways.report,
+    visualRivers: visualRivers.report,
     roads: infrastructure.roadReport,
   };
 
   const manifest = {
-    version: 9,
+    version: 10,
     source: { mapId: mapMetadata.map_id, mapVersion: mapMetadata.map_version },
     generatedSeed: SEED,
     world: { width: WORLD_WIDTH, height: WORLD_HEIGHT, overlapX: 250, wrapX: true },
@@ -281,7 +293,7 @@ async function main() {
       height: { url: 'height.f32', width: FIELD_WIDTH, height: FIELD_HEIGHT, format: 'r32float' },
       surface: { url: 'surface.rgba8', width: FIELD_WIDTH, height: FIELD_HEIGHT, format: 'rgba8uint' },
       roads: { url: 'roads.rg8', width: ID_WIDTH, height: ID_HEIGHT, format: 'rg8unorm' },
-      waterways: { url: 'waterways.r8', width: ID_WIDTH, height: ID_HEIGHT, format: 'r8unorm' },
+      waterways: { url: 'waterways.rg8', width: ID_WIDTH, height: ID_HEIGHT, format: 'rg8unorm' },
       coast: { url: 'coast.rg8', width: ID_WIDTH, height: ID_HEIGHT, format: 'rg8unorm' },
       provinceIds: { url: 'province-ids.u16', width: ID_WIDTH, height: ID_HEIGHT, format: 'r16uint' },
     },
@@ -313,6 +325,7 @@ async function main() {
       buildings: buildings.length / 8,
       connections: connections.length / 8,
       ...waterways.stats,
+      ...visualRivers.stats,
       ...infrastructure.stats,
       lamps: infrastructure.lamps.length / 8,
       barriers: infrastructure.barriers.length / 8,
@@ -326,7 +339,7 @@ async function main() {
     writeTyped('height.f32', heights),
     writeTyped('surface.rgba8', surface),
     writeTyped('roads.rg8', infrastructure.roadField),
-    writeTyped('waterways.r8', waterways.mask),
+    writeTyped('waterways.rg8', waterwayField),
     writeTyped('coast.rg8', bankField.field),
     writeTyped('borders.f32', borders),
     writeTyped('connections.f32', connections),

--- a/scripts/world/visual-rivers.mjs
+++ b/scripts/world/visual-rivers.mjs
@@ -1,0 +1,245 @@
+import { clamp, wrap } from './raster.mjs';
+
+// Visual-only rivers are implicit narrow gaps in the province topology rather
+// than authored movement-graph entities. Keep them readable without granting
+// movement semantics or widening broad ocean/lake coastlines.
+export const MINIMUM_VISUAL_RIVER_WIDTH = 7.6;
+export const VISUAL_RIVER_THRESHOLD = 0.45;
+const MINIMUM_COMPONENT_PIXELS = 5;
+const GRAPH_EXCLUSION_RADIUS_PIXELS = 2;
+const CANAL_EXCLUSION_HALF_WIDTH = 12;
+const CANAL_NAMES = new Set(['Kiel Canal', 'Suez Channel']);
+const BANK_DIRECTIONS = [
+  [1, 0],
+  [0, 1],
+  [1, 1],
+  [1, -1],
+];
+const NEIGHBORS = [
+  [-1, -1], [0, -1], [1, -1],
+  [-1, 0],           [1, 0],
+  [-1, 1],  [0, 1],  [1, 1],
+];
+
+function nearestLand(provinceIds, width, height, x, y, dx, dy, maxSteps) {
+  for (let step = 1; step <= maxSteps; step += 1) {
+    const py = y + dy * step;
+    if (py < 0 || py >= height) return 0;
+    const px = wrap(x + dx * step, width);
+    if (provinceIds[py * width + px] !== 0) return step;
+  }
+  return 0;
+}
+
+function markPixelCircle(field, width, height, cx, cy, radiusPixels) {
+  const radiusSquared = radiusPixels * radiusPixels;
+  const radius = Math.ceil(radiusPixels);
+  for (let oy = -radius; oy <= radius; oy += 1) {
+    const y = cy + oy;
+    if (y < 0 || y >= height) continue;
+    for (let ox = -radius; ox <= radius; ox += 1) {
+      if (ox * ox + oy * oy > radiusSquared) continue;
+      field[y * width + wrap(cx + ox, width)] = 255;
+    }
+  }
+}
+
+function addGraphExclusions({ exclusion, movementMask, networkData, connectionData, width, height, worldWidth, worldHeight }) {
+  const movementSeeds = [];
+  for (let index = 0; index < movementMask.length; index += 1) {
+    if (movementMask[index] === 0) continue;
+    exclusion[index] = 255;
+    movementSeeds.push(index);
+  }
+  for (const index of movementSeeds) {
+    const x = index % width;
+    const y = Math.floor(index / width);
+    markPixelCircle(exclusion, width, height, x, y, GRAPH_EXCLUSION_RADIUS_PIXELS);
+  }
+
+  const nodes = networkData.nodes;
+  const canalNodeIds = new Set(nodes.filter((node) => node.kind === 'sea_point' && CANAL_NAMES.has(node.location_name ?? '')).map((node) => node.node_id));
+  const pixelWidth = worldWidth / width;
+  const pixelHeight = worldHeight / height;
+  const canalRadiusPixels = CANAL_EXCLUSION_HALF_WIDTH / ((pixelWidth + pixelHeight) * 0.5);
+  const sampleSpacing = Math.max(1.5, Math.min(pixelWidth, pixelHeight) * 0.55);
+
+  for (const edge of connectionData.segments) {
+    if (edge.medium !== 'sea' || (!canalNodeIds.has(edge.node_a) && !canalNodeIds.has(edge.node_b))) continue;
+    const a = nodes[edge.node_a];
+    const b = nodes[edge.node_b];
+    if (!a || !b || a.kind !== 'sea_point' || b.kind !== 'sea_point') continue;
+    let bx = b.x;
+    const halfWorld = worldWidth * 0.5;
+    if (bx - a.x > halfWorld) bx -= worldWidth;
+    if (bx - a.x < -halfWorld) bx += worldWidth;
+    const dx = bx - a.x;
+    const dz = b.y - a.y;
+    const length = Math.hypot(dx, dz);
+    const segments = Math.max(1, Math.ceil(length / sampleSpacing));
+    for (let step = 0; step <= segments; step += 1) {
+      const t = step / segments;
+      const worldX = a.x + dx * t;
+      const worldY = a.y + dz * t;
+      const px = wrap(Math.floor(worldX / worldWidth * width), width);
+      const py = clamp(Math.floor(worldY / worldHeight * height), 0, height - 1);
+      markPixelCircle(exclusion, width, height, px, py, canalRadiusPixels);
+    }
+  }
+}
+
+function pruneSmallComponents(candidate, expansion, width, height) {
+  const visited = new Uint8Array(candidate.length);
+  const queue = [];
+  let keptComponents = 0;
+  let removedComponents = 0;
+  let removedPixels = 0;
+
+  for (let start = 0; start < candidate.length; start += 1) {
+    if (!candidate[start] || visited[start]) continue;
+    queue.length = 0;
+    queue.push(start);
+    visited[start] = 1;
+    const component = [];
+    for (let cursor = 0; cursor < queue.length; cursor += 1) {
+      const index = queue[cursor];
+      component.push(index);
+      const x = index % width;
+      const y = Math.floor(index / width);
+      for (const [dx, dy] of NEIGHBORS) {
+        const ny = y + dy;
+        if (ny < 0 || ny >= height) continue;
+        const nx = wrap(x + dx, width);
+        const next = ny * width + nx;
+        if (!candidate[next] || visited[next]) continue;
+        visited[next] = 1;
+        queue.push(next);
+      }
+    }
+
+    if (component.length >= MINIMUM_COMPONENT_PIXELS) {
+      keptComponents += 1;
+      continue;
+    }
+    removedComponents += 1;
+    removedPixels += component.length;
+    for (const index of component) {
+      candidate[index] = 0;
+      expansion[index] = 0;
+    }
+  }
+  return { keptComponents, removedComponents, removedPixels };
+}
+
+function neighborMaskValue(expansionWorld, stepWorld) {
+  if (expansionWorld <= 0) return 0;
+  // The source land/water contour lies halfway between pixel centers. Solve
+  // for the neighboring land sample value that moves a 0.45 filtered-mask
+  // contour outward by exactly expansionWorld, without a second dilation row.
+  const desired = 0.5 + expansionWorld / stepWorld;
+  if (desired <= 1) return clamp(1 + (VISUAL_RIVER_THRESHOLD - 1) / Math.max(0.5001, desired), 0, 1);
+  return clamp(VISUAL_RIVER_THRESHOLD / Math.max(0.0001, 2 - desired), 0, 1);
+}
+
+export function buildVisualRiverField({
+  provinceIds, movementMask, networkData, connectionData, width, height, worldWidth, worldHeight,
+}) {
+  const started = performance.now();
+  const pixelWidth = worldWidth / width;
+  const pixelHeight = worldHeight / height;
+  const averageTexelSize = (pixelWidth + pixelHeight) * 0.5;
+  const candidate = new Uint8Array(provinceIds.length);
+  const expansion = new Float32Array(provinceIds.length);
+  const exclusion = new Uint8Array(provinceIds.length);
+  addGraphExclusions({ exclusion, movementMask, networkData, connectionData, width, height, worldWidth, worldHeight });
+
+  let rawCandidatePixels = 0;
+  let minimumDetectedWidth = Infinity;
+  let maximumDetectedWidth = 0;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const index = y * width + x;
+      if (provinceIds[index] !== 0 || exclusion[index]) continue;
+      let sourceWidth = Infinity;
+      for (const [dx, dy] of BANK_DIRECTIONS) {
+        const stepWorld = Math.hypot(dx * pixelWidth, dy * pixelHeight);
+        const maxSteps = Math.ceil(MINIMUM_VISUAL_RIVER_WIDTH / stepWorld) + 1;
+        const positive = nearestLand(provinceIds, width, height, x, y, dx, dy, maxSteps);
+        if (!positive) continue;
+        const negative = nearestLand(provinceIds, width, height, x, y, -dx, -dy, maxSteps);
+        if (!negative) continue;
+        const widthWorld = (positive + negative - 1) * stepWorld;
+        sourceWidth = Math.min(sourceWidth, widthWorld);
+      }
+      if (!Number.isFinite(sourceWidth) || sourceWidth >= MINIMUM_VISUAL_RIVER_WIDTH - 0.01) continue;
+      candidate[index] = 1;
+      expansion[index] = (MINIMUM_VISUAL_RIVER_WIDTH - sourceWidth) * 0.5;
+      rawCandidatePixels += 1;
+      minimumDetectedWidth = Math.min(minimumDetectedWidth, sourceWidth);
+      maximumDetectedWidth = Math.max(maximumDetectedWidth, sourceWidth);
+    }
+  }
+
+  const components = pruneSmallComponents(candidate, expansion, width, height);
+  const mask = new Uint8Array(provinceIds.length);
+  const clearance = new Uint8Array(provinceIds.length);
+  let centerPixels = 0;
+  let widenedLandPixels = 0;
+  let maximumExpansion = 0;
+
+  for (let index = 0; index < candidate.length; index += 1) {
+    if (!candidate[index]) continue;
+    centerPixels += 1;
+    mask[index] = 255;
+    clearance[index] = 255;
+    maximumExpansion = Math.max(maximumExpansion, expansion[index]);
+    const x = index % width;
+    const y = Math.floor(index / width);
+    for (const [dx, dy] of NEIGHBORS) {
+      const ny = y + dy;
+      if (ny < 0 || ny >= height) continue;
+      const nx = wrap(x + dx, width);
+      const neighbor = ny * width + nx;
+      if (provinceIds[neighbor] === 0 || exclusion[neighbor]) continue;
+      const stepWorld = Math.hypot(dx * pixelWidth, dy * pixelHeight);
+      const value = Math.round(neighborMaskValue(expansion[index], stepWorld) * 255);
+      if (value <= mask[neighbor]) continue;
+      if (mask[neighbor] === 0 && value > 0) widenedLandPixels += 1;
+      mask[neighbor] = value;
+      // Any land cell whose filtered mask contributes to the widened channel
+      // must stay clear of generated trees/buildings, even if its center falls
+      // just outside the final shader cutoff.
+      if (value > 0) clearance[neighbor] = 255;
+    }
+  }
+
+  const effectivePixels = mask.reduce((count, value) => count + (value / 255 > VISUAL_RIVER_THRESHOLD ? 1 : 0), 0);
+  return {
+    mask,
+    clearance,
+    report: {
+      source: 'province-zero narrow-channel topology (no movement semantics)',
+      method: 'opposing-bank minimum-width expansion',
+      minimumRenderedWidth: MINIMUM_VISUAL_RIVER_WIDTH,
+      shaderThreshold: VISUAL_RIVER_THRESHOLD,
+      texelSize: averageTexelSize,
+      minimumComponentPixels: MINIMUM_COMPONENT_PIXELS,
+      rawCandidatePixels,
+      centerPixels,
+      effectivePixels,
+      widenedLandPixels,
+      graphExclusionPixels: exclusion.reduce((count, value) => count + (value > 0 ? 1 : 0), 0),
+      keptComponents: components.keptComponents,
+      removedSmallComponents: components.removedComponents,
+      removedSmallPixels: components.removedPixels,
+      detectedSourceWidthRange: rawCandidatePixels ? [minimumDetectedWidth, maximumDetectedWidth] : [0, 0],
+      maximumBankExpansion: maximumExpansion,
+      buildMilliseconds: performance.now() - started,
+    },
+    stats: {
+      visualRiverComponents: components.keptComponents,
+      visualRiverCenterPixels: centerPixels,
+      visualRiverExpandedPixels: effectivePixels,
+    },
+  };
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -156,8 +156,8 @@ export class WorldRenderer {
       'rg8unorm', new Uint8Array(roadFieldBuffer), this.manifest.fields.roads.width * 2,
     );
     this.waterwayTexture = this.uploadTexture(
-      'authored waterway mask', this.manifest.fields.waterways.width, this.manifest.fields.waterways.height,
-      'r8unorm', new Uint8Array(waterwayFieldBuffer), this.manifest.fields.waterways.width,
+      'movement and visual-river field', this.manifest.fields.waterways.width, this.manifest.fields.waterways.height,
+      'rg8unorm', new Uint8Array(waterwayFieldBuffer), this.manifest.fields.waterways.width * 2,
     );
     this.coastTexture = this.uploadTexture(
       'signed-distance bank field', this.manifest.fields.coast.width, this.manifest.fields.coast.height,

--- a/src/shaders.ts
+++ b/src/shaders.ts
@@ -58,12 +58,11 @@ fn sampleMaterial(layer: i32, worldPosition: vec3f, scale: f32) -> vec3f {
 @fragment
 fn terrainFragment(input: TerrainVertexOutput) -> @location(0) vec4f {
   let provinceId = provinceAt(input.mapUv);
-  // The waterway mask is baked from the same dense samples as the river mesh.
-  // Clip coarse terrain triangles out of that corridor so they cannot bridge
-  // a narrow authored gap and progressively bury the water surface. Static
-  // The signed-distance bank field preserves the source topology while
-  // removing nearest-neighbor stair steps from coasts and visual channels.
-  if (landAt(input.mapUv) <= 0.5 || waterwayAt(input.mapUv) > 0.45) { discard; }
+  // Movement rivers carry an explicit ribbon clip mask. Visual-only rivers
+  // remain generic water, but their second mask channel expands only narrow
+  // province-zero channels so coarse terrain cannot bridge over them.
+  let riverField = waterwayFieldAt(input.mapUv);
+  if (landAt(input.mapUv) <= 0.5 || riverField.r > 0.45 || riverField.g > 0.45) { discard; }
 
   let surface = surfaceAt(input.mapUv);
   let terrain = surface.r;
@@ -142,8 +141,10 @@ fn terrainFragment(input: TerrainVertexOutput) -> @location(0) vec4f {
     let steepness = clamp((1.0 - normal.y) * 7.5, 0.0, 1.0);
     lit = mix(vec3f(0.08, 0.31, 0.22), vec3f(0.96, 0.22, 0.08), smoothstep(0.08, 0.82, steepness));
   } else if (debugMode == 6u) {
-    let channel = waterwayAt(input.mapUv);
-    lit = mix(vec3f(0.025, 0.035, 0.038), vec3f(0.04, 0.88, 0.98), channel);
+    let channels = waterwayFieldAt(input.mapUv);
+    lit = vec3f(0.025, 0.035, 0.038);
+    lit = mix(lit, vec3f(0.04, 0.88, 0.98), channels.r);
+    lit = mix(lit, vec3f(0.18, 0.48, 0.98), channels.g * (1.0 - channels.r));
   } else if (debugMode == 7u) {
     let coast = landAt(input.mapUv);
     lit = mix(vec3f(0.74, 0.42, 0.16), vec3f(0.16, 0.62, 0.30), smoothstep(0.52, 0.96, coast));
@@ -151,11 +152,12 @@ fn terrainFragment(input: TerrainVertexOutput) -> @location(0) vec4f {
     let footprint = max(roadData.r, roadData.g * 0.62);
     lit = mix(vec3f(0.025, 0.03, 0.032), mix(vec3f(0.94, 0.62, 0.10), vec3f(0.95, 0.18, 0.08), roadData.r), footprint);
   } else if (debugMode == 9u) {
-    let channel = waterwayAt(input.mapUv);
+    let channels = waterwayFieldAt(input.mapUv);
     let roadSignal = max(roadData.r, roadData.g * 0.45);
     lit = vec3f(0.15, 0.17, 0.16);
     lit = mix(lit, vec3f(0.96, 0.61, 0.12), roadSignal);
-    lit = mix(lit, vec3f(0.02, 0.77, 0.96), channel);
+    lit = mix(lit, vec3f(0.02, 0.77, 0.96), channels.r);
+    lit = mix(lit, vec3f(0.18, 0.48, 0.98), channels.g * (1.0 - channels.r));
   }
 
   if (uniforms.terrainInfo.w > 0.5) {
@@ -213,14 +215,21 @@ fn waterVertex(input: WaterVertexInput, @builtin(instance_index) instanceIndex: 
 
 @fragment
 fn waterFragment(input: WaterVertexOutput) -> @location(0) vec4f {
-  if (landAt(input.mapUv) >= 0.5 || waterwayAt(input.mapUv) > 0.45) { discard; }
+  let riverField = waterwayFieldAt(input.mapUv);
+  if (riverField.r > 0.45) { discard; }
+  if (landAt(input.mapUv) >= 0.5 && riverField.g <= 0.45) { discard; }
+  let visualRiver = smoothstep(0.18, 0.72, riverField.g);
   let debugMode = u32(uniforms.map.w + 0.5);
-  if (debugMode == 6u) { return vec4f(0.012, 0.025, 0.032, 1.0); }
+  if (debugMode == 6u) {
+    return vec4f(mix(vec3f(0.012, 0.025, 0.032), vec3f(0.18, 0.48, 0.98), visualRiver), 1.0);
+  }
   if (debugMode == 7u) {
-    let depthDebug = waterDepthAt(input.mapUv);
+    let depthDebug = mix(waterDepthAt(input.mapUv), 0.08, visualRiver);
     return vec4f(mix(vec3f(0.16, 0.66, 0.82), vec3f(0.015, 0.11, 0.28), depthDebug), 1.0);
   }
-  if (debugMode == 9u) { return vec4f(0.025, 0.12, 0.25, 1.0); }
+  if (debugMode == 9u) {
+    return vec4f(mix(vec3f(0.025, 0.12, 0.25), vec3f(0.18, 0.48, 0.98), visualRiver), 1.0);
+  }
   let time = uniforms.sunTime.w;
   let world = input.worldPosition.xz;
   let warp = vec2f(valueNoise(world / 175.0 + vec2f(time * 0.025, -time * 0.017)),
@@ -234,14 +243,14 @@ fn waterFragment(input: WaterVertexOutput) -> @location(0) vec4f {
   let viewDirection = normalize(uniforms.camera.xyz - input.worldPosition);
   let fresnel = pow(1.0 - max(dot(normal, viewDirection), 0.0), 4.5);
   let sun = pow(max(dot(reflect(-normalize(uniforms.sunTime.xyz), normal), viewDirection), 0.0), 112.0);
-  let depth = waterDepthAt(input.mapUv);
+  let depth = mix(waterDepthAt(input.mapUv), 0.08, visualRiver);
   let shelf = smoothstep(0.0, 0.44, depth);
   let shallow = vec3f(0.12, 0.48, 0.52);
   let deep = vec3f(0.025, 0.16, 0.255);
   var color = mix(shallow, deep, shelf);
   color = mix(color, vec3f(0.40, 0.60, 0.63), fresnel * 0.64);
   let foamBreak = valueNoise(world / 11.0 + warp * 2.4 + vec2f(time * 0.15, -time * 0.09));
-  let foam = bankAt(input.mapUv) * smoothstep(0.54, 0.82, foamBreak + waveA * 0.12);
+  let foam = bankAt(input.mapUv) * (1.0 - visualRiver * 0.80) * smoothstep(0.54, 0.82, foamBreak + waveA * 0.12);
   color = mix(color, vec3f(0.73, 0.82, 0.77), foam * 0.52);
   color += vec3f(1.0, 0.86, 0.61) * sun * (0.34 + ripple * 0.05);
   let fog = smoothstep(4000.0, 12000.0, distance(uniforms.camera.xyz, input.worldPosition));

--- a/src/shaders/common.ts
+++ b/src/shaders/common.ts
@@ -72,7 +72,9 @@ fn bankFieldAt(uvInput: vec2f) -> vec2f { return textureSampleLevel(coastTexture
 fn landAt(uvInput: vec2f) -> f32 { return bankFieldAt(uvInput).r; }
 fn bankAt(uvInput: vec2f) -> f32 { return bankFieldAt(uvInput).g; }
 fn roadAt(uvInput: vec2f) -> vec2f { return textureSampleLevel(roadTexture, materialSampler, wrappedUv(uvInput), 0.0).rg; }
-fn waterwayAt(uvInput: vec2f) -> f32 { return textureSampleLevel(waterwayTexture, materialSampler, wrappedUv(uvInput), 0.0).r; }
+fn waterwayFieldAt(uvInput: vec2f) -> vec2f { return textureSampleLevel(waterwayTexture, materialSampler, wrappedUv(uvInput), 0.0).rg; }
+fn waterwayAt(uvInput: vec2f) -> f32 { return waterwayFieldAt(uvInput).r; }
+fn visualRiverAt(uvInput: vec2f) -> f32 { return waterwayFieldAt(uvInput).g; }
 
 fn terrainNormal(uv: vec2f) -> vec3f {
   let dimensions = vec2f(textureDimensions(heightTexture));

--- a/tests/shaders.test.ts
+++ b/tests/shaders.test.ts
@@ -10,10 +10,13 @@ describe('WGSL programs', () => {
     expect(terrainShader).not.toContain('if (elevation < 12.0)');
   });
 
-  it('uses the signed-distance bank field without closing thin visual channels', () => {
-    expect(terrainShader).toContain('if (landAt(input.mapUv) <= 0.5 || waterwayAt(input.mapUv) > 0.45)');
-    expect(waterShader).toContain('if (landAt(input.mapUv) >= 0.5 || waterwayAt(input.mapUv) > 0.45)');
+  it('clips terrain around widened visual-only channels without replacing movement-river ribbons', () => {
+    expect(terrainShader).toContain('riverField.r > 0.45 || riverField.g > 0.45');
+    expect(waterShader).toContain('if (riverField.r > 0.45)');
+    expect(waterShader).toContain('landAt(input.mapUv) >= 0.5 && riverField.g <= 0.45');
     expect(terrainShader).toContain('bankAt(input.mapUv)');
+    expect(waterShader).toContain('mix(waterDepthAt(input.mapUv), 0.08, visualRiver)');
+    expect(waterShader).toContain('(1.0 - visualRiver * 0.80)');
     expect(waterShader).not.toContain('if (provinceAt(input.mapUv)');
   });
 
@@ -30,7 +33,8 @@ describe('WGSL programs', () => {
     expect(waterwayShader).toContain('brokenStreak');
     expect(waterwayShader).toContain('let canal = input.kind > 0.5');
     expect(waterwayShader).toContain('oceanDeep');
-    expect(terrainShader).toContain('waterwayAt(input.mapUv) > 0.45');
+    expect(terrainShader).toContain('riverField.r > 0.45');
+    expect(terrainShader).toContain('riverField.g > 0.45');
     expect(terrainShader).toContain('debugMode == 6u');
     expect(terrainShader).toContain('debugMode == 9u');
     expect(lineShader).toContain('lineParams.mode == 2u');

--- a/tests/world-data.test.ts
+++ b/tests/world-data.test.ts
@@ -29,10 +29,10 @@ function viewU32(bytes: Buffer): Uint32Array {
   return new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
 }
 
-describe('generated v9 world package', () => {
+describe('generated v10 world package', () => {
   it('preserves the canonical world and exposes simplified roads plus supplied waterways', async () => {
     const data = await manifest();
-    expect(data.version).toBe(9);
+    expect(data.version).toBe(10);
     expect(data.world).toEqual(expect.objectContaining({ width: 13_562, height: 7_000, wrapX: true }));
     expect(data.provinces).toHaveLength(3_303);
     expect(new Set(data.provinces.map((province) => province.id)).size).toBe(3_303);
@@ -65,7 +65,7 @@ describe('generated v9 world package', () => {
     const [vertexBytes, indexBytes, networkBytes, maskBytes, provinceIdBytes, nodeBytes, reportBytes] = await Promise.all([
       readFile('public/world/waterway-vertices.f32'), readFile('public/world/waterway-indices.u32'),
       readFile('public/world/waterway-network-lines.f32'),
-      readFile('public/world/waterways.r8'),
+      readFile('public/world/waterways.rg8'),
       readFile('public/world/province-ids.u16'),
       readFile('material/movement/network_nodes.json', 'utf8'), readFile('public/world/world-generation-report.json', 'utf8'),
     ]);
@@ -76,7 +76,7 @@ describe('generated v9 world package', () => {
     const riverNames = new Set(report.waterways.riverSystems);
     const sourceRiverPoints = source.nodes.filter((node) => node.kind === 'sea_point' && riverNames.has(node.location_name));
     const sourceCanalPoints = source.nodes.filter((node) => node.kind === 'sea_point' && ['Kiel Canal', 'Suez Channel'].includes(node.location_name));
-    expect(report.version).toBe('world-generation-v9');
+    expect(report.version).toBe('world-generation-v10');
     expect(report.waterways.animatedSurface).toBe(true);
     expect(report.waterways.animation).toBe('tangent-advection-domain-warp');
     expect(report.waterways.minimumRiverWidth).toBeGreaterThanOrEqual(11);
@@ -99,8 +99,25 @@ describe('generated v9 world package', () => {
       expect(network[offset + 5]).toBeGreaterThanOrEqual(0.4);
       expect([0, 1]).toContain(network[offset + 6]);
     }
-    expect(maskBytes.byteLength).toBe(data.fields.waterways.width * data.fields.waterways.height);
-    expect(maskBytes.some((value) => value > 0)).toBe(true);
+    expect(data.fields.waterways.format).toBe('rg8unorm');
+    expect(maskBytes.byteLength).toBe(data.fields.waterways.width * data.fields.waterways.height * 2);
+    expect(maskBytes.some((value, index) => index % 2 === 0 && value > 0)).toBe(true);
+    expect(maskBytes.some((value, index) => index % 2 === 1 && value > 0)).toBe(true);
+    expect(report.visualRivers.minimumRenderedWidth).toBeGreaterThanOrEqual(7.5);
+    expect(report.visualRivers.minimumRenderedWidth).toBeLessThan(report.waterways.minimumRiverWidth);
+    expect(report.visualRivers.centerPixels).toBeGreaterThan(0);
+    expect(report.visualRivers.widenedLandPixels).toBeGreaterThan(0);
+    expect(data.counts.visualRiverComponents).toBeGreaterThan(0);
+    let widenedVisualLandPixels = 0;
+    let movementVisualOverlap = 0;
+    for (let pixel = 0; pixel < provinceIds.length; pixel += 1) {
+      const movement = maskBytes[pixel * 2] / 255;
+      const visual = maskBytes[pixel * 2 + 1] / 255;
+      if (visual > 0.45 && provinceIds[pixel] !== 0) widenedVisualLandPixels += 1;
+      if (movement > 0.45 && visual > 0.45) movementVisualOverlap += 1;
+    }
+    expect(widenedVisualLandPixels).toBeGreaterThan(0);
+    expect(movementVisualOverlap).toBe(0);
     expect(vertices.every(Number.isFinite)).toBe(true);
     let centerVertices = 0;
     for (let vertex = 0; vertex < data.buffers.waterwayVertices.count; vertex += 113) {
@@ -123,7 +140,7 @@ describe('generated v9 world package', () => {
       // Mouth overlap samples deliberately stop clipping the base ocean once
       // both authored banks have opened. Every sample over land must still
       // carry the terrain-removal mask.
-      if (provinceIds[pixel] !== 0) expect(maskBytes[pixel]).toBe(255);
+      if (provinceIds[pixel] !== 0) expect(maskBytes[pixel * 2]).toBe(255);
     }
     expect(centerVertices).toBeGreaterThan(10_000);
     for (let index = 0; index < indices.length; index += 127) expect(indices[index]).toBeLessThan(data.buffers.waterwayVertices.count);


### PR DESCRIPTION
## Summary

- detect narrow province-zero visual-only water channels from opposing-bank topology without adding movement semantics
- widen those channels to a 7.6 world-unit minimum while leaving movement rivers at their existing 11+ unit ribbon width
- pack the waterway field as RG (`R = movement-river clip`, `G = visual-only widening`) and bump the generated world manifest to v10
- clip terrain out of widened visual channels and allow generic shallow-water rendering into the expanded footprint
- attenuate old-bank foam/depth artifacts, reserve prop clearance around the widened presentation footprint, and expose both channel classes in debug views
- keep roads, province IDs, and movement connectivity unchanged

## Validation

- deterministic `npm run build:world` completed through final asset generation
- generated 510 retained visual-channel components and 23,984 effective visual-river pixels
- 12,284 effective visual-river pixels extend onto source-land cells, which is the terrain-overlap fix
- 0 render-threshold overlap between movement-river and visual-only mask channels
- visual-only minimum width: 7.6; movement-river minimum width: 11
- road results unchanged: 7,805 logical / 7,665 visible / 140 hidden
- `node --check scripts/build-world.mjs` and `node --check scripts/world/visual-rivers.mjs` pass
- generated `public/world` binaries are intentionally not committed

## Environment note

A full `npm test` / TypeScript + Dawn shader test run could not be completed in this workspace because `npm ci` hit the execution cap before installing the required type/test packages. The world-generation build itself completed and the generated field invariants were validated separately.