### PR TITLE
Slide the dossier up from below instead of fading it in

### DIFF
--- a/src/menu/menu.css
+++ b/src/menu/menu.css
@@ -46,7 +46,7 @@
 }
 
 /* ---------- main area (menu screen + subpages share this) ---------- */
-.ifm__main-area { position: relative; grid-row: 1; min-height: 0; }
+.ifm__main-area { position: relative; grid-row: 1; min-height: 0; overflow: hidden; }
 .ifm__screen { position: absolute; inset: 0; z-index: 2; overflow: auto; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3.2vh; padding: 3vh 3vw; }
 .ifm__screen[hidden] { display: none; }
 

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -19,7 +19,8 @@ export function mountMenu(handlers: MenuHandlers): void {
 
   let busy = false;
   let openScreen: string | null = null;
-  let transitionFile: HTMLElement | null = null;
+  let transitionPage: HTMLElement | null = null;
+  let riseDistance = 0;
 
   /**
    * One update() drives every sub-motion from the same t (0=on the menu,
@@ -27,11 +28,13 @@ export function mountMenu(handlers: MenuHandlers): void {
    * is already at cover-fit scale, and zooming further just softens it).
    * The logo/cards are measured to move by the exact same pixel amount the
    * backdrop's visible window shifts, so they read as scrolling with the
-   * desk rather than drifting at their own independent speed.
+   * desk rather than drifting at their own independent speed. The dossier
+   * page rides the same pan curve, sliding up fully opaque from below the
+   * fold so it reads as having been on the desk the whole time rather than
+   * fading into place.
    */
   function update(t: number): void {
     const panT = smooth(phase(t, 0, 0.92));
-    const inT = smooth(phase(t, 0.62, 1));
 
     const box = map.getBoundingClientRect();
     const renderedHeight = box.width * MAP_ASPECT;
@@ -44,16 +47,18 @@ export function mountMenu(handlers: MenuHandlers): void {
 
     main.style.transform = `translateY(${(-offsetPx).toFixed(2)}px)`;
 
-    if (transitionFile) {
-      transitionFile.style.opacity = String(inT);
-      transitionFile.style.transform = `translateY(${((1 - inT) * 28).toFixed(2)}px)`;
+    if (transitionPage) {
+      transitionPage.style.transform = `translateY(${((1 - panT) * riseDistance).toFixed(2)}px)`;
     }
   }
 
-  async function playTransition(fileEl: HTMLElement, direction: 1 | -1): Promise<void> {
-    transitionFile = fileEl;
+  async function playTransition(page: HTMLElement, direction: 1 | -1): Promise<void> {
+    transitionPage = page;
+    page.style.transform = 'none';
+    riseDistance = page.getBoundingClientRect().height;
+    update(direction === 1 ? 0 : 1);
     await runChoreo(OPEN_DURATION, direction, update);
-    transitionFile = null;
+    transitionPage = null;
   }
 
   async function openDossier(card: HTMLButtonElement): Promise<void> {
@@ -68,9 +73,8 @@ export function mountMenu(handlers: MenuHandlers): void {
     openScreen = name;
 
     page.hidden = false;
-    fileEl.style.opacity = '0';
     page.style.pointerEvents = 'none';
-    await playTransition(fileEl, 1);
+    await playTransition(page, 1);
     page.style.pointerEvents = '';
     main.style.pointerEvents = 'none';
     busy = false;
@@ -86,7 +90,7 @@ export function mountMenu(handlers: MenuHandlers): void {
     busy = true;
     main.style.pointerEvents = '';
     page.style.pointerEvents = 'none';
-    await playTransition(fileEl, -1);
+    await playTransition(page, -1);
     page.hidden = true;
     page.style.pointerEvents = '';
     openScreen = null;


### PR DESCRIPTION
@Zoande — front-page menu transition fix, over to you to review.

## Problem

Clicking one of the four menu cards pans the desk backdrop down and scrolls the logo/cards up with it (good), but the dossier itself **faded into place** — `.ifm__file` animated `opacity` `0 → 1` with a small 28px nudge on its own delayed phase (`0.62..1`). It read as the panel *materialising* on top of the desk rather than being part of the scene.

## Change

The dossier now **slides up from below the fold**, fully opaque the whole way, on the **same `panT` curve** as the backdrop pan and the outgoing menu. It's parked one container-height down at rest and translates up to centre as `panT` goes `0 → 1`, so it reads as having been sitting lower on the desk the entire time — the camera pan just brings it into frame.

- Motion is driven off `panT` (not the old `inT`), so the panel, the desk, and the menu all move on one clock.
- `.ifm__main-area` is now `overflow: hidden`, so the dossier emerges from **behind the footer bar** instead of sliding over it.
- The transform is on the `.ifm__subpage` element, **not** `.ifm__file` — that keeps `.ifm__file`'s own `overflow:auto` scroll container untouched, so no scrollbar flashes on `.ifm__subpage` mid-transition (verified: document + subpage overflow stays 0 throughout).
- Close reverses symmetrically (choreo runs `t: 1 → 0`).
- The old `inT` / opacity write is gone; `fileEl.style.opacity = '0'` removed from `openDossier`.

## Design note

The panel travels one full container-height, not the exact pixel amount the backdrop window shifts (`offsetPx` ≈ 729px on 1080p vs. an ~1176px pan window). Rigidly desk-coupling it would leave the panel peeking above the bottom edge on the idle menu, so it matches the *curve* and drops the fade — which is what "there the whole time" actually needs here.

## Verification

- `npm run check` passes (tsc + eslint + 62 vitest tests).
- Manually checked open + close for New Campaign and Map Sandbox at 6× slow-mo and normal speed: opaque throughout, emerges from behind the footer, no scrollbar flash, rests centred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)