### PR TITLE
Fix #21: map clicks select a province instead of changing ownership

### DIFF
--- a/src/picking.ts
+++ b/src/picking.ts
@@ -29,6 +29,21 @@ export function pickTerrainPoint(
   return result[2] < 0 || result[2] >= worldHeight ? null : result;
 }
 
+export type PrimaryClickAction =
+  | { readonly kind: 'select'; readonly encodedProvinceId: number }
+  | { readonly kind: 'clear-selection' };
+
+/**
+ * Resolve a normal left-click / tap on the map. This is selection only: it never
+ * changes province ownership. Ownership mutation goes through an explicit
+ * gameplay/debug pathway (see WorldRenderer.forceCaptureProvinceAt).
+ */
+export function resolvePrimaryClick(encodedProvinceId: number): PrimaryClickAction {
+  return encodedProvinceId > 0
+    ? { kind: 'select', encodedProvinceId }
+    : { kind: 'clear-selection' };
+}
+
 export function createHoverInfo(
   encodedId: number,
   provinces: ReadonlyMap<number, ProvinceRecord>,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -13,7 +13,7 @@ import {
   createEmptyRenderWorkload, PerformanceMonitor,
   type PerformancePhases, type PerformanceSnapshot, type RenderCategory,
 } from './performance-monitor';
-import { createHoverInfo, pickTerrainPoint } from './picking';
+import { createHoverInfo, pickTerrainPoint, resolvePrimaryClick } from './picking';
 import { PoliticalCache } from './political-cache';
 import { createRendererLayouts, createRendererPipelines } from './renderer-pipelines';
 import { beginWorldFrame, submitWorldFrame } from './renderer-frame';
@@ -51,6 +51,7 @@ export class WorldRenderer {
   onStats?: (stats: FrameStats) => void;
   onDiplomacyChange?: (state: DiplomacyState) => void;
   onProvinceCaptured?: (provinceId: number, previousCountry: CountryRecord, player: CountryRecord) => void;
+  onProvinceSelected?: (info: HoverInfo | null) => void;
   onTimeOfDayChange?: (state: TimeOfDayState) => void;
 
   private readonly canvas: HTMLCanvasElement;
@@ -170,6 +171,7 @@ export class WorldRenderer {
   };
   private pointer = { x: 0, y: 0, inside: false };
   private hoveredId = 0;
+  private selectedId = 0;
   private pickingDirty = false;
   private lastPickedCameraRevision = -1;
   private lastPickTime = -Infinity;
@@ -426,6 +428,7 @@ export class WorldRenderer {
     this.onStats = undefined;
     this.onDiplomacyChange = undefined;
     this.onProvinceCaptured = undefined;
+    this.onProvinceSelected = undefined;
     this.onTimeOfDayChange = undefined;
     if (!this.deviceReady) return;
     this.device.removeEventListener('uncapturederror', this.onUncapturedError);
@@ -754,7 +757,7 @@ export class WorldRenderer {
         this.pointer.inside = true;
         this.finishPicking(this.provinceAtScreenPoint(event.clientX, event.clientY), performance.now());
       }
-      this.captureProvinceAt(event.clientX, event.clientY);
+      this.selectProvinceAt(event.clientX, event.clientY);
     }, { signal });
     window.addEventListener('pointercancel', () => {
       this.clickStart = undefined;
@@ -1259,16 +1262,41 @@ export class WorldRenderer {
     return point ? this.sampleProvince(point[0], point[2]) : 0;
   }
 
-  private captureProvinceAt(clientX: number, clientY: number): void {
+  private selectProvinceAt(clientX: number, clientY: number): void {
+    const action = resolvePrimaryClick(this.provinceAtScreenPoint(clientX, clientY));
+    const encodedId = action.kind === 'select' ? action.encodedProvinceId : 0;
+    if (encodedId === this.selectedId) return;
+    this.selectedId = encodedId;
+    this.onProvinceSelected?.(encodedId ? this.toHoverInfo(encodedId) : null);
+  }
+
+  /** Encoded (1-based) id of the selected province, or 0 when nothing is selected. */
+  get selectedProvinceId(): number {
+    return this.selectedId;
+  }
+
+  clearProvinceSelection(): void {
+    if (!this.selectedId) return;
+    this.selectedId = 0;
+    this.onProvinceSelected?.(null);
+  }
+
+  /**
+   * Explicit developer/gameplay pathway for transferring ownership of the
+   * province under a screen point to the player. A normal map click never
+   * reaches this; it must be invoked deliberately (e.g. a diagnostics tool).
+   */
+  forceCaptureProvinceAt(clientX: number, clientY: number): boolean {
     const encodedId = this.provinceAtScreenPoint(clientX, clientY);
-    if (!encodedId) return;
+    if (!encodedId) return false;
     const previousCountryId = this.provinceOwners[encodedId];
-    if (this.diplomaticRelations.get(previousCountryId) !== 'war') return;
+    if (this.diplomaticRelations.get(previousCountryId) !== 'war') return false;
     const previousCountry = this.countryById.get(previousCountryId);
     const player = this.countryById.get(this.playerCountryId);
-    if (!previousCountry || !player) return;
+    if (!previousCountry || !player) return false;
     this.setProvinceOwner(encodedId - 1, this.playerCountryId);
     this.onProvinceCaptured?.(encodedId - 1, previousCountry, player);
+    return true;
   }
 
   private finishPicking(encodedId: number, started: number): { raycastMs: number; hoverUiMs: number } {

--- a/tests/picking.test.ts
+++ b/tests/picking.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePrimaryClick } from '../src/picking';
+
+describe('resolvePrimaryClick', () => {
+  it('selects the province under a normal left-click', () => {
+    expect(resolvePrimaryClick(7)).toEqual({ kind: 'select', encodedProvinceId: 7 });
+  });
+
+  it('clears the selection when the click misses any province', () => {
+    expect(resolvePrimaryClick(0)).toEqual({ kind: 'clear-selection' });
+  });
+
+  it('never resolves a primary click to an ownership mutation', () => {
+    for (const encodedId of [0, 1, 42, 999]) {
+      const action = resolvePrimaryClick(encodedId);
+      expect(['select', 'clear-selection']).toContain(action.kind);
+    }
+  });
+});


### PR DESCRIPTION
## What

A normal left-click / tap on the map called `captureProvinceAt`, which called `setProvinceOwner` whenever the clicked province's owner was at war with the player. Ordinary map inspection was destructive and bypassed any future unit/order/combat flow.

## Changes

- **`resolvePrimaryClick` (`src/picking.ts`)** — pure helper that turns a hit-tested encoded province id into a `select` / `clear-selection` action and nothing else. There is no code path from here to an ownership mutation; `tests/picking.test.ts` locks that in.
- **`WorldRenderer`** — tracks `selectedId`, exposes `selectedProvinceId` (getter) and `clearProvinceSelection()`, and fires `onProvinceSelected(HoverInfo | null)` on change. Pointer-up now calls `selectProvinceAt`.
- The previous capture logic is unchanged but only reachable through a new explicit `forceCaptureProvinceAt(clientX, clientY): boolean` method, intended for a diagnostics/dev tool. `onProvinceCaptured` still fires from that path.

## Acceptance criteria

- [x] A normal click never changes ownership by itself
- [x] Selected provinces remain inspectable while relations are at war (selection is independent of diplomacy)
- [x] Ownership mutation occurs only through an explicit pathway (`forceCaptureProvinceAt`)
- [x] Interaction regression test added (`tests/picking.test.ts`)

## Notes / follow-ups

- No visible selection highlight yet — selection is state + `onProvinceSelected` callback only. A highlight pass and a province command/details panel are issue #14.
- Wiring a debug-only force-capture control into the diagnostics UI is deliberately **not** in this PR: that touches `main.ts` / the menu, which the in-flight `feat/audio-foundation` branch also edits. Easy to add once that lands.

Based on `main` (not PR #29) so it merges independently.

Refs #21

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)