### PR TITLE
Fix #28 (partial): rank national over province borders at overview zoom

### DIFF
--- a/src/shaders/lines.ts
+++ b/src/shaders/lines.ts
@@ -87,6 +87,22 @@ fn lineVertex(@builtin(vertex_index) vertexIndex: u32, @builtin(instance_index) 
     color = select(vec4f(0.05, 0.91, 1.0, 0.94), vec4f(0.98, 0.71, 0.12, 0.96), line.b.z > 0.5);
   }
 
+  // Line hierarchy at overview zoom (uniforms.interaction.y is the camera
+  // orbit distance). National borders must stay legible when zoomed out;
+  // province borders are secondary and should recede so political structure
+  // reads at a glance, then return progressively toward regional zoom.
+  // Hovered lines and non-border modes keep their own styling.
+  if (lineParams.mode == 0u && !hovered) {
+    let overviewFade = smoothstep(3200.0, 7600.0, uniforms.interaction.y);
+    if (countryCasing > 0.5) {
+      widthPixels += overviewFade * 0.5;
+      color.a = mix(color.a, 0.92, overviewFade * 0.6);
+      innerColor.a = mix(innerColor.a, 0.95, overviewFade * 0.6);
+    } else {
+      color.a *= mix(1.0, 0.22, overviewFade);
+    }
+  }
+
   let clip = select(clip0, clip1, endpoint == 1u);
   let pixelOffset = normal * side * widthPixels * 2.0 / uniforms.viewport.xy;
   var output: LineOutput;

--- a/tests/shaders.test.ts
+++ b/tests/shaders.test.ts
@@ -101,6 +101,16 @@ describe('WGSL programs', () => {
     expect(lineShader).toContain('mix(0.30, 0.10, nearFactor)');
   });
 
+  it('ranks national over province borders at overview zoom without touching hover or other modes', () => {
+    expect(lineShader).toContain('if (lineParams.mode == 0u && !hovered) {');
+    expect(lineShader).toContain('let overviewFade = smoothstep(3200.0, 7600.0, uniforms.interaction.y)');
+    expect(lineShader).toContain('color.a = mix(color.a, 0.92, overviewFade * 0.6)');
+    expect(lineShader).toContain('color.a *= mix(1.0, 0.22, overviewFade)');
+    // The pre-existing near-zoom weights are still the baseline the fade builds on.
+    expect(lineShader).toContain('mix(0.60, 0.94, nearFactor)');
+    expect(lineShader).toContain('mix(0.30, 0.10, nearFactor)');
+  });
+
   it('builds purely visual periodic polar shelves with water gaps and an outer fog', () => {
     expect(polarCapShader).toContain('const POLAR_CAP_DEPTH');
     expect(polarCapShader).toContain('let angle = mapX / uniforms.map.x * TAU');


### PR DESCRIPTION
Addresses #28 (presentation-only slice — see Scope).

## Problem

At overview zoom province boundaries, country boundaries and road lines read at similar weight/value, so the political structure of the map was hard to scan quickly.

## Change (`src/shaders/lines.ts`, border mode only)

Adds a zoom-dependent line hierarchy driven by the camera orbit distance (`uniforms.interaction.y` — the same signal the shader already uses for `nearFactor`). It **builds on** the existing near-zoom weights (`mix(0.60, 0.94, nearFactor)` for national, `mix(0.30, 0.10, nearFactor)` for province) rather than replacing them:

| Line | Near zoom | Overview zoom (new) |
|---|---|---|
| National border | unchanged | alpha held toward 0.92, +0.5px width |
| Province border | unchanged | alpha × 0.22, returns progressively when zooming in |
| Hovered line | unchanged (gold, strongest) | unchanged |
| River / frontline / diplomacy modes | unchanged | unchanged |

Net effect at overview: national boundaries stay legible, province detail recedes into the terrain and reappears as the camera drops toward regional zoom.

## Scope / what this PR does NOT do

- **Selection edge treatment** ("selected/frontline: strongest") — needs renderer-side selection state that doesn't exist yet on `main` (see #21 / #14). Left for a follow-up so this stays a pure shader change.
- **Road value/material vs borders** — roads are already a separate shader (`infrastructure.ts`) with a distinct dirt-brown / dotted-gold material, so they're visually distinct from the dark-teal/tan border lines today. Road *tiering* is #6.
- Map-mode colour validation (political / diplomacy / clear / balanced) is a visual-QA step — see below.

## Direction reference

"Slicker lines while keeping the rustic battle-map look" (Call of War 2.0 map notes); HoI4-style progressive province detail on zoom-in.

## Tests

- `tests/shaders.test.ts` — new case `ranks national over province borders at overview zoom without touching hover or other modes`; existing Dawn WGSL semantic-compilation case compiles the modified shader.
- `npm run check` green.

## Verification / follow-up

- [ ] Overview + regional screenshots in political / diplomacy / clear / balanced map modes (acceptance criterion). `npm run visual-check` needs a headed Chrome + dev server; not run here.
- [ ] Selection / hovered-province edge treatment once selection state lands (#21).

Branched from `main`; touches only `src/shaders/lines.ts` + its test — merges independently of #29, the audio branch, and the other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)