### PR TITLE
Perf: cap the HiDPI render scale at 1.5x device pixels

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -774,7 +774,12 @@ export class WorldRenderer {
   }
 
   private resize(): void {
-    const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+    // Cap the backing-store scale below the full device pixel ratio. Every
+    // world pass is full-screen, so a 2x buffer on a HiDPI / 4K panel is ~4x
+    // the fragment work of a 1x buffer; 1.5 keeps the map crisp while giving
+    // roughly 44% of that cost back as headroom for weaker GPUs and for other
+    // subsystems (audio, UI) sharing the frame.
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, 1.5);
     const width = Math.max(1, Math.floor(this.canvas.clientWidth * pixelRatio));
     const height = Math.max(1, Math.floor(this.canvas.clientHeight * pixelRatio));
     if (this.canvas.width === width && this.canvas.height === height) return;


### PR DESCRIPTION
## Why

Motivated by a report that the (separate) audio-foundation branch "crashes and lags very bad" on a real machine. I read that branch's `src/audio/audio-manager.ts` and its `main.ts` / `menu.ts` wiring: the audio code is event-driven with no per-frame work and no node leak, so the lag is not caused by anything I can fix there. But it did prompt looking at how much headroom the renderer leaves.

`src/renderer.ts:resize()` sized the drawing buffer at `min(devicePixelRatio, 2)`. Every world pass is full-screen, so on a 2x HiDPI / 4K panel that is ~4x the fragment work of a 1x buffer, and it also scales the viewport-derived rain particle count (`Math.ceil(width * height / 2200)`).

## Change

One line: cap at `1.5` instead of `2`.

- On a 2x display: ~44% fewer fragments per pass (1.5² / 2²), plus a smaller particle budget, for a barely perceptible change in map sharpness.
- On 1x or 1.5x displays: **no change**.
- No new per-frame state, no adaptive loop, no swapchain churn — `resize()` still early-returns when the computed size is unchanged.

## Not included (deliberately)

- **Adaptive / dynamic resolution.** Mutating the backing-store size per frame triggers `context.configure()` + depth-texture recreation each step and can oscillate; that failure mode looks exactly like the symptom being chased. If a dynamic scaler is wanted it should be its own change with hysteresis and a settings toggle.
- Any change to the audio branch — not mine to touch, and not where the problem is.

## Tests

`npm run check` green (no test asserts the pixel-ratio cap).

## Verification / follow-up

- [ ] `npm run performance-check` before/after on a HiDPI machine to quantify the p95 / GPU-ms delta (needs headed Chrome + dev server; not run here).
- [ ] Consider exposing render scale in Settings (relates to #13).

Branched from `main`. Touches only `src/renderer.ts:resize()`; does not overlap #29, the audio branch, or the other open PRs (#30's `renderer.ts` edits are elsewhere in the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)