### PR TITLE
Fix: regional-zoom forest renders as flat black blobs

### DIFF
--- a/src/shaders/terrain.ts
+++ b/src/shaders/terrain.ts
@@ -143,9 +143,15 @@ fn terrainFragment(input: TerrainVertexOutput) -> @location(0) vec4f {
     baseColor = mix(baseColor, bakedSurface.rgb, smoothstep(3000.0, 4500.0, uniforms.interaction.y));
   }
   if (terrain == 3u) {
+    // Forests should read as a darker, denser green mass from strategic
+    // altitude, but the previous canopy colour was near-black and blended in
+    // at 0.78. Stacked on baked prop AO and surface shading it collapsed
+    // regional-zoom forest into flat black blobs. Lift the target to a deep
+    // forest green and ease the blend so the canopy still darkens the terrain
+    // without crushing it.
     let forestDistance = distance(uniforms.camera.xyz, input.worldPosition);
-    let canopySignal = vec3f(0.115, 0.31, 0.14) * (0.86 + variation * 0.24);
-    baseColor = mix(baseColor, canopySignal, smoothstep(1750.0, 3150.0, forestDistance) * 0.78);
+    let canopySignal = vec3f(0.17, 0.34, 0.18) * (0.86 + variation * 0.24);
+    baseColor = mix(baseColor, canopySignal, smoothstep(1750.0, 3150.0, forestDistance) * 0.5);
   }
 
   if (uniforms.interaction.z > 0.5 && uniforms.map.w < 0.5) {


### PR DESCRIPTION
Found while play-testing `main` in the renderer (not a filed issue — happy to open one if preferred).

## Problem

At regional zoom, densely forested provinces render as flat near-black amoeba shapes covering large parts of the visible map. It reads as scorched earth, not woodland. Toggling props off does **not** remove it, so it's terrain-shader, not prop geometry.

Cause: `src/shaders/terrain.ts`, forest branch (`terrain == 3u`):

```wgsl
let canopySignal = vec3f(0.115, 0.31, 0.14) * (0.86 + variation * 0.24);
baseColor = mix(baseColor, canopySignal, smoothstep(1750.0, 3150.0, forestDistance) * 0.78);
```

`(0.115, 0.31, 0.14)` is nearly black, blended in at **0.78**. It then stacks multiplicatively with the baked prop-occlusion alpha (`baseColor *= bakedSurface.a`, ~0.78–0.85 under canopy from `bakePropAo`) and `surfaceLight()`, so lit forest lands around 7–10% luminance.

## Change

One hunk in `terrain.ts`:

```wgsl
let canopySignal = vec3f(0.17, 0.34, 0.18) * (0.86 + variation * 0.24);
baseColor = mix(baseColor, canopySignal, smoothstep(1750.0, 3150.0, forestDistance) * 0.5);
```

Deep forest green instead of black, blend eased to 0.5. Forests still read as a darker, denser mass than open grassland from strategic altitude. Close-up (`forestDistance < 1750`) is unchanged.

## Verification

Ran the change in the live renderer. Before/after screenshots at the `riverMouth` (East Africa) and `europe` showcases at ~500–780 orbit distance — forest goes from black splotches to legible green woodland with the trees still visible on top; grass, mountains, rivers, borders unchanged. `npm run check` green (Dawn WGSL compile covers the edited shader; `canopySignal` is not test-pinned).

## Follow-ups (separate)

- `bakePropAo` tree/building AO strengths (0.22 / 0.28 in `scripts/world/terrain-precompute.mjs`) also contribute to under-canopy darkening; could be softened too but it's a defensible contact-shadow effect and left alone here.

Branched from `main`. Touches only `src/shaders/terrain.ts` — independent of #29, the audio branch, and PRs #30–#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)