### PR TITLE
Fix: polar ice cap renders as salt-and-pepper static at overview zoom

### DIFF
--- a/src/shaders/polar-caps.ts
+++ b/src/shaders/polar-caps.ts
@@ -81,11 +81,15 @@ fn polarCapFragment(input: PolarCapOutput) -> @location(0) vec4f {
   let shoreline = mix(bankAt(boundaryUv), 0.0, deepWaterBlend);
   let water = oceanSurfaceColor(input.worldPosition, waterDepth, shoreline, 0.0);
 
-  let iceGrain = valueNoise(input.worldPosition.xz / 31.0 + vec2f(input.side * 11.0, 0.0));
+  // Grain and crevasse noise were sampled at 31 and 16 world units - finer
+  // than a screen pixel at overview zoom, so the ice cap read as salt-and-
+  // pepper static. Widen both to feature scale so they show as broad shading
+  // and occasional cracks instead of per-pixel noise.
+  let iceGrain = valueNoise(input.worldPosition.xz / 96.0 + vec2f(input.side * 11.0, 0.0));
   let broadIce = valueNoise(input.worldPosition.xz / 230.0 + vec2f(0.0, input.side * 9.0));
-  let crevasse = smoothstep(0.70, 0.91, valueNoise(input.worldPosition.xz / 16.0));
+  let crevasse = smoothstep(0.74, 0.93, valueNoise(input.worldPosition.xz / 150.0));
   var iceColor = mix(vec3f(0.57, 0.72, 0.76), vec3f(0.88, 0.93, 0.92), broadIce * 0.72 + iceGrain * 0.18);
-  iceColor = mix(iceColor, vec3f(0.32, 0.54, 0.63), crevasse * 0.28);
+  iceColor = mix(iceColor, vec3f(0.32, 0.54, 0.63), crevasse * 0.24);
   let iceLight = surfaceLight(vec3f(0.0, 1.0, 0.0));
   var color = mix(water, iceColor * iceLight, ice);
   color = mix(color, color * vec3f(0.74, 0.80, 0.83), uniforms.weather.x * 0.30);

--- a/tests/shaders.test.ts
+++ b/tests/shaders.test.ts
@@ -106,6 +106,8 @@ describe('WGSL programs', () => {
     expect(polarCapShader).toContain('let angle = mapX / uniforms.map.x * TAU');
     expect(polarCapShader).toContain('channelCut');
     expect(polarCapShader).toContain('let polarFog = smoothstep');
+    expect(polarCapShader).toContain('valueNoise(input.worldPosition.xz / 150.0)');
+    expect(polarCapShader).not.toContain('valueNoise(input.worldPosition.xz / 16.0)');
     expect(polarCapShader).not.toContain('provinceAt(input');
     expect(polarCapShader).not.toContain('navigationAt(input');
   });


### PR DESCRIPTION
Found play-testing. Not a filed issue.

## Problem

The procedural polar ice caps shimmer with per-pixel black/blue noise at overview zoom — reads as TV static, not snow. `polarCapFragment` samples its grain and crevasse `valueNoise` at **31** and **16** world units; a screen pixel at overview covers many world units, so both alias badly.

## Change (`src/shaders/polar-caps.ts`, fragment only)

- `iceGrain` noise scale `31 → 96`
- `crevasse` noise scale `16 → 150`, threshold `0.70/0.91 → 0.74/0.93`, tint `0.28 → 0.24`

The cap now shows broad shading and occasional wide cracks instead of static. Vertex geometry (relief, water channels, the polar-fog fade) is untouched.

## Tests

`tests/shaders.test.ts` — asserts the new crevasse scale and the absence of the old one; Dawn WGSL compile covers the shader. `npm run check` green.

## Verification

Before/after at the north cap in the running renderer — dense flecks become smooth ice with a few soft crevasse fields.

Branched from `main`; touches only `src/shaders/polar-caps.ts` + its test. Independent of #29 and PRs #30–#38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)