### PR TITLE
Fix: forests and cities are ringed by a hard black AO scar

### DIFF
--- a/scripts/world/terrain-precompute.mjs
+++ b/scripts/world/terrain-precompute.mjs
@@ -244,13 +244,16 @@ function bakePropAo(output, width, height, worldWidth, worldHeight, trees, build
       }
     }
   };
+  // Contact darkening only. Higher strengths baked a hard near-black ring into
+  // the terrain albedo around every forest and city that read as scorched
+  // ground once terrain shading and canopy tint stacked on top.
   for (let offset = 0; offset < trees.length; offset += 8) {
     const radius = Math.max(6.5, trees[offset + 2] * 5.2);
-    splat(trees[offset], trees[offset + 1], radius, radius, 0.22);
+    splat(trees[offset], trees[offset + 1], radius, radius, 0.13);
   }
   for (let offset = 0; offset < buildings.length; offset += 8) {
     splat(buildings[offset], buildings[offset + 1], Math.max(5, buildings[offset + 2] * 0.72),
-      Math.max(5, buildings[offset + 4] * 0.72), 0.28);
+      Math.max(5, buildings[offset + 4] * 0.72), 0.17);
   }
 }
 


### PR DESCRIPTION
Follow-up to #37 (noted there). Found play-testing.

## Problem

`bakePropAo` (`scripts/world/terrain-precompute.mjs`) splats prop occlusion into the terrain-albedo alpha at strength **0.22** (trees) / **0.28** (buildings). The terrain shader applies it as `baseColor *= bakedSurface.a`, then terrain shading and the regional canopy tint multiply on top — so the ground under and around every forest and city reads as a hard near-black ring of scorched earth.

## Change

Strengths `0.22 → 0.13` and `0.28 → 0.17`. Still a visible contact darkening beside props, no longer a burn scar. Splat radii and the `min()` accumulation are unchanged.

Regenerates the baked terrain albedo texture — **run `npm run build:world` after merging**; no manifest/schema change.

## Verification

Rebuilt the world and viewed forest/city edges in the running renderer — the black halo becomes a soft contact shadow; grass under sparse tree cover stays green.

`npm run check` green (after rebuild).

Branched from `main`; touches only `scripts/world/terrain-precompute.mjs`. Independent of #29 and PRs #30–#39. Pairs with #37 (canopy) — together they clear up regional-zoom forest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)