### PR TITLE
Fix: vertical drag-pan is inverted

### DIFF
--- a/src/camera.ts
+++ b/src/camera.ts
@@ -213,7 +213,10 @@ export class StrategyCamera {
         const dy = centerY - this.pinchCenter[1];
         if (this.pinchDistance > 0) this.zoomAt(centerX, centerY, this.pinchDistance / distance);
         const panScale = this.distance * 0.00145;
-        this.pan(-dx * panScale, -dy * panScale);
+        // Grab-and-drag: the point under the cursor should follow it on both
+        // axes. `pan`'s forward axis points up-screen, so dragging down must
+        // pan forward (+dy), not backward.
+        this.pan(-dx * panScale, dy * panScale);
         this.pinchCenter = [centerX, centerY];
         this.pinchDistance = distance;
         return;
@@ -223,7 +226,7 @@ export class StrategyCamera {
       const dy = event.clientY - this.lastPointer[1];
       this.lastPointer = [event.clientX, event.clientY];
       const scale = this.distance * 0.00145;
-      this.pan(-dx * scale, -dy * scale);
+      this.pan(-dx * scale, dy * scale);
       return;
     }
     if (!this.dragMode) return;
@@ -235,7 +238,8 @@ export class StrategyCamera {
       this.pitch = clamp(this.pitch + dy * 0.0035, 0.43, 1.23);
     } else {
       const scale = this.distance * 0.00145;
-      this.pan(-dx * scale, -dy * scale);
+      // Grab-and-drag: dragging down pulls the map down, so pan forward (+dy).
+      this.pan(-dx * scale, dy * scale);
     }
   };
 


### PR DESCRIPTION
User report: "movement with mouse is very weird, like it feels inverted, I should be able to drag to the place I want to go."

## Problem

Horizontal drag already behaves as grab-and-drag (the point under the cursor stays under it). The **vertical** axis was flipped: dragging down moved the camera *south* (`target.z` up), so the map appeared to slide *up* against the cursor.

Cause: `Camera.pan(right, forward)` — its `forward` axis points up-screen (`forwardZ = -cos(yaw)`), so a downward drag (`+dy`) must pan `+forward`. All three call sites passed `-dy`.

## Change (`src/camera.ts`)

`this.pan(-dx * scale, -dy * scale)` → `this.pan(-dx * scale, dy * scale)` at the three pan sites: mouse drag, one-finger touch, two-finger touch-pan. Horizontal axis (`-dx`) and orbit (right-drag yaw/pitch) unchanged.

## Verification

In the running renderer: scripted a 200px downward drag over Europe — the map content followed the cursor down and `camera.target.z` went 2050 → 1609 (moved north, as grab-drag-down requires). `npm run check` green; `tests/camera-touch.test.ts` (asserts the horizontal axis) still passes.

Branched from `main`; one file. Independent of #29 and PRs #30–#40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)