### PR TITLE
Graphics Quality presets (Low / Medium / High / Ultra)

### DIFF
--- a/docs/BRANCH_STATUS.md
+++ b/docs/BRANCH_STATUS.md
@@ -1,0 +1,82 @@
+# Branch status
+
+Snapshot taken while Zoande is away. `origin` = `DH4410/ironfronts` (fork,
+where the PR branches live). `upstream` = `Zoande/ironfronts`.
+`upstream/main` HEAD = `7ff1e2e`.
+
+**Nothing was force-pushed, no open-PR branch was modified, and no branch that
+carries unique unmerged work was deleted.** One branch was deleted: see the
+bottom of this file for the proof.
+
+## A. Open-PR branches — KEEP EXACTLY AS THEY ARE
+
+All are `origin/DH4410`, all target `Zoande:main`, all currently `MERGEABLE`
+against `main` and merge cleanly in sequence with each other (verified by a
+throwaway sequential test-merge). See `PR_MERGE_PLAN.md` for order and overlaps.
+
+| Branch | PR | Base | Unique work | Rebuild `world`? | Safe to delete? |
+|---|---|---|---|---|---|
+| `fix/dossier-slide-up-from-below` | #29 | `main` | menu dossier slides up instead of fading | no | **No — open PR** |
+| `fix/click-selects-province` | #30 | `main` | click selects, not captures; `forceCaptureProvinceAt` | no | **No — open PR** |
+| `fix/zoom-aware-country-labels` | #31 | `main` | map-space label size cap | no | **No — open PR** |
+| `fix/coastal-buildings-over-water` | #32 | `main` | footprint water rejection **+ lower city building density / island hamlets** | **yes** | **No — open PR** |
+| `fix/coastline-halo-overview` | #33 | `main` | shallow-shelf + foam + sheen calmed | no | **No — open PR** |
+| `fix/border-hierarchy-overview` | #34 | `main` | national vs province border weight at overview | no | **No — open PR** |
+| `fix/city-regional-lod` | #35 | `main` | shader city LOD **+ building-lighting floor (no black cities)** | no | **No — open PR** |
+| `perf/lower-hidpi-render-scale` | #36 | `main` | render-scale cap `2 → 1.5` | no | **No — open PR** (but **superseded**, see below) |
+| `fix/regional-forest-canopy-blackout` | #37 | `main` | forest canopy lift | no | **No — open PR** |
+| `fix/visual-river-fragmentation` | #38 | `main` | river edge de-speckle + per-river flow | no | **No — open PR** |
+| `fix/polar-cap-ice-stipple` | #39 | `main` | polar-cap noise scale-up | no | **No — open PR** |
+| `fix/soften-prop-ground-ao` | #40 | `main` | baked prop-AO strengths reduced | **yes** | **No — open PR** |
+| `fix/pan-vertical-inverted` | #41 | `main` | vertical drag-pan sign fix | no | **No — open PR** |
+| `fix/terrain-mountain-blackout` | #42 | `main` | rock lift + hillshade + relief noise + forest-floor lift + desert tone | no | **No — open PR** |
+
+`origin/perf/lower-hidpi-render-scale` (#36) is **functionally superseded** by
+`feat/graphics-quality-settings`: that branch replaces the same one line in
+`renderer.ts resize()` with a preset-driven render scale (Medium = 1.0,
+High = 1.25). Recommendation: close #36, or merge it first as a stopgap and let
+the graphics-settings author drop the duplicate line (~3-line conflict). Do
+**not** delete the branch while the PR is open.
+
+## B. Active development branches — KEEP
+
+| Branch | Purpose | Open PR | Base | Unique work | Status | Safe to delete? |
+|---|---|---|---|---|---|---|
+| `origin/feat/audio-foundation` | Audio layer (UI SFX, music director, ambience) **+ the menu crash-resistance work**: compositor-only dossier animation, serialized AudioContext unlock, no hover-triggered unlock, low-cost UI sounds, deferred world renderer. | none yet | `7ff1e2e` (current `main`) | 63 commits, 0 behind. ~30 files incl. `src/audio/*`, `src/menu/menu.ts`, `index.html`, `tests/music-director.test.ts`, `tests/ui-audio-profile.test.ts`. | Active. Not stale. | **No.** Deleting this destroys the audio layer and the menu-freeze fixes. |
+| `feat/graphics-quality-settings` | This task: Graphics Quality presets. | opening now (`DH4410:feat/graphics-quality-settings`) | `7ff1e2e` | `src/graphics/quality.ts`, `src/chunk-visibility.ts`, `src/renderer.ts`, `src/main.ts`, `src/menu/menu.ts`, `src/menu/menu.css`, `index.html`, `tests/graphics-quality.test.ts`. | Active. | **No.** |
+
+## C. Temporary review / integration branches — KEEP while useful
+
+| Branch | Purpose | Open PR | Base | Unique work | Status | Safe to delete? |
+|---|---|---|---|---|---|---|
+| `origin/review/claude-ui-stack` | Combines the audio/menu work with PRs #29–#42 for **combined manual + CI testing**. Adds a combined-UI capture script and a GitHub Actions workflow (`Run automated combined UI review`, tolerant of CI runners without a Dawn GPU adapter). | none (not an upstream PR) | `7ff1e2e` | 83 commits, 0 behind. | Useful right now for end-to-end testing of the whole stack. | **No** while it is being used for review. It is **not** an upstream merge branch — do not convert it into one, do not force-push it. May be rebuilt/updated for testing. |
+| `preview-all` (local only, not pushed) | Claude's local integration of `main` + all 14 PRs (+ this feature) for screenshot/perf testing. | n/a | `upstream/main` | none unique — pure merge of pushed branches. | Local scratch. | Local-only; irrelevant to the remote. Rebuilt on demand. |
+
+## D. Stale / superseded branches — documented, NOT deleted (except one, below)
+
+| Branch | Purpose | Open PR | Base | Unique work | Status | Safe to delete? | Notes |
+|---|---|---|---|---|---|---|---|
+| `origin/feature/in-game-ui-world-polish` | Earlier visual-polish pass: "Reduce dense forest and settlement visual clutter", "Tone down ocean cyan saturation", "Mute strategic political palette", `external-models.test.ts`. | none | `98b3d35` (old — pre menu merge) | **16 commits, 15 behind `main`.** | Stale base. Overlaps in *intent* with #33 (ocean cyan), #34 + #37 (political/forest clutter) but the commits are **not** identical and are **not** merged anywhere. | **No — not proven dead.** | Zoande to decide: cherry-pick anything still wanted, or close. Do not delete until then. |
+| `origin/preview-in-game-ui` | Codespaces-preview sibling of the above: "Add one-click Codespaces preview" + two "Sync … into Codespaces preview" commits. | none | `98b3d35` | 14 commits, 15 behind. Includes a `.devcontainer` / one-click preview config not present elsewhere. | Stale base; preview tooling may still be wanted. | **No — not proven dead.** | Keep until Zoande confirms the Codespaces preview is obsolete. |
+| `upstream/fix/widen-visual-rivers` | Zoande's earlier river-widening work. | none | — | **Ancestor of `upstream/main`** (its tip is the merge-base with `main`) — i.e. already fully merged. | Merged. | **N/A — it lives on Zoande's repo.** Not ours to touch. | Mentioned only for completeness. Leave it for Zoande. |
+
+## Branch deleted
+
+**`origin/feature/dossier-main-menu`** — deleted from the `DH4410` fork.
+
+Proof it was provably dead and safe:
+
+- `git rev-list --count upstream/main..origin/feature/dossier-main-menu` → **0**
+  (every commit on the branch is already in `upstream/main`).
+- Its tip `20c11ab` is an ancestor of `upstream/main`; it was merged via
+  `Zoande/ironfronts` **PR #3** ("Merge pull request #3 from
+  DH4410/feature/dossier-main-menu", commit `3d70004`), which is closed.
+- No open PR references it (`gh pr list --state open` → only #29–#42).
+- No other branch is based on it: `feat/audio-foundation`,
+  `review/claude-ui-stack`, and every `fix/*` PR branch have merge-base
+  `7ff1e2e` with `main`, not `20c11ab`.
+- Fully recoverable — every commit remains in `upstream/main` history; the ref
+  can be re-created with `git branch feature/dossier-main-menu 20c11ab` if ever
+  wanted.
+
+Nothing else was deleted. When in doubt, the branch was kept and documented.

--- a/docs/PR_MERGE_PLAN.md
+++ b/docs/PR_MERGE_PLAN.md
@@ -1,0 +1,92 @@
+# PR merge plan (#29–#42) + `feat/graphics-quality-settings`
+
+For Zoande, tomorrow. **Nothing here has been merged or closed.**
+
+## Summary
+
+- All 14 open PRs (#29–#42) are authored by `DH4410`, target `Zoande:main`,
+  and **merge cleanly onto `main` in the recommended order** and cleanly with
+  each other (verified with a throwaway sequential test-merge; `npm run check`
+  passes on the fully-merged result — 72 tests).
+- Only **two** PRs regenerate `public/world/` and need
+  `npm run build:world` after merge: **#32** and **#40**.
+- **#36 is superseded** by `feat/graphics-quality-settings` (same one line in
+  `renderer.ts`).
+- Four PRs are deliberately *partial* and leave their tracking issue open:
+  **#31** (issue #5), **#34** (#28), **#35** (#7), and #32 covers #4 fully but
+  only part of the wider city-visual work.
+
+## Overlap map (files touched)
+
+| File | PRs that touch it |
+|---|---|
+| `src/renderer.ts` | **#30**, **#36** (+ `feat/graphics-quality-settings`) |
+| `src/shaders/terrain.ts` | **#37**, **#42** |
+| `scripts/world/*` (regenerates world) | **#32** (`instances.mjs`, `build-world.mjs`), **#40** (`terrain-precompute.mjs`) |
+| `tests/shaders.test.ts` | #33, #34, #35, #38, #39 (non-adjacent additions — 3-way merges fine) |
+| `src/menu/menu.ts` + `menu.css` | **#29** (+ `feat/graphics-quality-settings`, + `feat/audio-foundation`) |
+| `src/shaders/common.ts` | #33 | 
+| `src/shaders/lines.ts` | #34 |
+| `src/shaders/props.ts` | #35 |
+| `src/shaders/waterways.ts` | #38 |
+| `src/shaders/polar-caps.ts` | #39 |
+| `src/camera.ts` | #41 |
+| `src/country-labels/layout.ts` | #31 |
+| `src/picking.ts` | #30 |
+
+`#30` and `#36` both edit `renderer.ts` but in **different functions**
+(`#30`: pointer-up handler + `captureProvinceAt`→`selectProvinceAt`;
+`#36`: `resize()`) — they auto-merge. `#37` and `#42` both edit `terrain.ts`
+in **different regions** (`#37`: the `terrain == 3u` canopy block; `#42`: the
+rock branches + the lighting term) — they auto-merge, but see "Reconcile after
+merge".
+
+## Recommended order
+
+Order is by blast radius / confidence, not by conflict avoidance (there are no
+conflicts among #29–#42). Run `npm run build:world && npm run check` after the
+two rebuild PRs.
+
+| # | PR | Purpose | Risk | Overlaps | Rebuild world? | Order | Ready? |
+|---|---|---|---|---|---|---|---|
+| 1 | **#29** | Dossier slides up instead of fading | Low (menu only) | menu.ts/.css with `feat/audio-foundation` + graphics feature (different regions) | no | **1** | Ready — you said this is approved |
+| 2 | **#41** | Fix inverted vertical drag-pan | Low (`camera.ts`, 3 sign flips) | none | no | **2** | Ready |
+| 3 | **#39** | Polar ice-cap noise scale-up | Low (1 shader hunk) | `tests/shaders.test.ts` | no | **3** | Ready |
+| 4 | **#37** | Forest canopy lift (regional) | Low (1 `terrain.ts` hunk) | #42 (`terrain.ts`) | no | **4** | Ready |
+| 5 | **#42** | Mountain black-void fix + hillshade + relief noise + forest-floor lift + desert tone | Medium (several `terrain.ts` hunks; new per-fragment noise gated to `< 3200` orbit) | **#37** (`terrain.ts`) | no | **5** (right after #37) | Ready. After both land, fold the canopy + rock + forest-floor lifts into one block (see below). Consider gating the relief noise on `uniforms.weather.z` once the graphics feature is in. |
+| 6 | **#33** | Coastline halo / shallow sheen calmed | Low | `tests/shaders.test.ts` | no | **6** | Ready. Reconcile with `feature/in-game-ui-world-polish`'s "Tone down ocean cyan" if that branch is revived — pick one. |
+| 7 | **#38** | River edge de-speckle + per-river flow | Low | `tests/shaders.test.ts` | no | **7** | Ready. The underlying per-mask-texel *geometry* is still a quilt — a real fix is a `buildVisualWaterways` rewrite (overlaps `upstream/fix/widen-visual-rivers`); noted in the PR. |
+| 8 | **#34** | National vs province border weight at overview | Low | `tests/shaders.test.ts` | no | **8** | Ready. **Partial** — issue #28 stays open (no selection-edge treatment; that needs renderer state, see #30/#14). |
+| 9 | **#31** | Map-space country-label size cap | Low | none | no | **9** | Ready. **Partial** — issue #5 stays open (no city-collision avoidance; needs city data threaded into `country-overlay.ts`). |
+| 10 | **#40** | Baked prop-AO strengths reduced | Low code, **regenerates world** | **#32** (both regenerate `public/world/`) | **YES** — `npm run build:world` after merge | **10** | Ready. Merge #40 then #32, rebuild once after #32. |
+| 11 | **#32** | Reject building footprints over water **+ fewer/spaced city buildings, island hamlets** | Medium — **regenerates world**; whole-map building count 22,188 → ~6,200 (deliberate; verify it isn't too sparse for you) | **#40** | **YES** — `npm run build:world` after merge, *before* trusting `tests/world-data.test.ts` (`npm test` does this automatically; a bare `vitest` will not) | **11** | Ready. If the city thin-out is too aggressive, bump the `(populationScale - 3) * 10` multiplier in `instances.mjs`. |
+| 12 | **#35** | Shader city regional LOD + building-lighting floor | Low (shader only) | `tests/shaders.test.ts` | no | **12** | Ready. **Partial** — issue #7 stays open. This is shader-fade only; a true instance-budget LOD now exists in `feat/graphics-quality-settings` (`capVisibleInstances`) — reconcile after both land (the graphics feature should own the instance budget; #35 keeps the per-building height/footprint fade). |
+| 13 | **#36** | Cap HiDPI render scale `2 → 1.5` | Low (1 line) | **superseded** by `feat/graphics-quality-settings` | no | **13** — or **close it** | **Needs a decision.** Either close #36 (its cap becomes the Medium/High preset default) or merge it here as a stopgap and let the graphics-settings author drop the duplicated line (~3-line conflict in `resize()`). |
+| 14 | **#30** | Map click selects a province instead of capturing it | **Medium–High — behavioural.** Ownership change moves behind `forceCaptureProvinceAt`. No debug UI wired for the new path (noted in PR). | `renderer.ts` with #36 / graphics feature (different functions) | no | **14 (last)** | Ready, but review the interaction change yourself — it changes what a plain click does. |
+| 15 | `feat/graphics-quality-settings` | Graphics Quality presets (this task) | Medium — new renderer knobs, new settings UI, new visible-instance budget | `renderer.ts` (**conflicts with #36 only**), `menu.ts`/`.css` (auto-merge with #29), `main.ts`, `index.html`, new `graphics/quality.ts` + `chunk-visibility.ts` | no | **after the stack** | Ready. If #36 was closed, merges clean. If #36 was merged, resolve the 3-line `resize()` conflict (keep the preset version, drop `Math.min(dpr, 1.5)`). |
+
+## Reconcile after merge (not blocking)
+
+- **#37 + #42** — both improve `terrain.ts` readability. Once both are in,
+  collapse the canopy lift (#37), the rock/hill lifts + hillshade + relief
+  noise + forest-floor lift (#42) into one coherent "terrain readability"
+  block, and gate the relief-noise cost on `uniforms.weather.z` (the graphics
+  feature's detail factor).
+- **#35 + `feat/graphics-quality-settings`** — the graphics feature adds a real
+  renderer-side visible-instance budget (`capVisibleInstances`) and preset
+  draw-distance scaling. #35's shader-only regional fade should stay for the
+  per-building height/footprint shrink; the *count* reduction should be owned
+  by the budget. Trim any now-redundant shader culling in #35 after both land.
+- **#33 / #34 vs `feature/in-game-ui-world-polish`** — that stale branch has
+  "Tone down ocean cyan" and "Mute strategic political palette" commits that
+  overlap #33 and #34 in intent. If it is revived, don't apply both.
+- **#36 vs `feat/graphics-quality-settings`** — pick one owner of the render
+  scale (recommended: the graphics feature).
+
+## Things that stay open after this batch
+
+Issues **#5, #7, #28** (partials #31, #35, #34). Follow-ups noted in the PR
+bodies: selection-edge treatment for #28, city-label collision avoidance for
+#5, a true `buildVisualWaterways` ribbon rewrite for the river geometry,
+road-tiering for #6, coastline terrace/step artefacts, and bridges where roads
+cross rivers.

--- a/index.html
+++ b/index.html
@@ -183,6 +183,15 @@
               <div class="ifm__list">
                 <label class="ifm__row" style="cursor:default"><span><b>Master volume</b><small>Overall audio output.</small></span><input type="range" min="0" max="100" value="74"></label>
                 <label class="ifm__row" style="cursor:default"><span><b>Render scale</b><small>World renderer resolution.</small></span><input type="range" min="70" max="100" value="100"></label>
+                <div class="ifm__row ifm__row--stack">
+                  <span><b>Graphics quality</b><small id="ifm-graphics-blurb">High-quality strategic map</small></span>
+                  <div class="ifm__seg" id="ifm-graphics-quality" role="group" aria-label="Graphics quality">
+                    <button type="button" data-graphics-quality="low">Low</button>
+                    <button type="button" data-graphics-quality="medium">Medium</button>
+                    <button type="button" data-graphics-quality="high" aria-pressed="true" class="is-selected">High</button>
+                    <button type="button" data-graphics-quality="ultra">Ultra</button>
+                  </div>
+                </div>
                 <button class="ifm__primary" id="ifm-apply-settings">Apply Preferences <span>&rarr;</span></button>
               </div>
             </div>

--- a/src/chunk-visibility.ts
+++ b/src/chunk-visibility.ts
@@ -18,6 +18,7 @@ export function buildTerrainVisibility(
   cameraPosition: ArrayLike<number>,
   sampleHeight: (x: number, z: number) => number,
   intersectsView: (centerX: number, centerZ: number, radius: number) => boolean,
+  lodScale = 1,
 ): TerrainVisibility {
   const chunksX = manifest.terrain.chunksX;
   const chunksY = manifest.terrain.chunksY;
@@ -37,7 +38,9 @@ export function buildTerrainVisibility(
           centerX - cameraPosition[0], centerY - cameraPosition[1], centerZ - cameraPosition[2],
         );
         if (!intersectsView(centerX, centerZ, chunkRadius)) continue;
-        const lod = distance < 1_050 ? 0 : distance < 2_350 ? 1 : distance < 5_000 ? 2 : 3;
+        const lod = distance < 1_050 * lodScale ? 0
+          : distance < 2_350 * lodScale ? 1
+          : distance < 5_000 * lodScale ? 2 : 3;
         lodEntries[lod].push(copy * chunksPerWorld + chunkY * chunksX + chunkX);
       }
     }
@@ -111,4 +114,35 @@ export function buildPropVisibility(
     }
   }
   return { instances, draws, visibleChunks };
+}
+
+/**
+ * Hard visible-instance budget. When a frame's culled prop set still exceeds
+ * `budget`, keep a stride-sampled subset within every draw (so each LOD /
+ * mesh group is thinned proportionally and the spatial spread is preserved).
+ * This is real submitted-instance reduction, not a shader-side fade.
+ */
+export function capVisibleInstances(visibility: PropVisibility, budget: number): PropVisibility {
+  const total = visibility.instances.length;
+  if (!Number.isFinite(budget) || total <= budget || total === 0) return visibility;
+
+  const keepRatio = budget / total;
+  const kept: number[] = [];
+  const draws: PropVisibility['draws'] = [];
+  for (const draw of visibility.draws) {
+    const target = Math.max(1, Math.round(draw.instanceCount * keepRatio));
+    const stride = draw.instanceCount / target;
+    const firstInstance = kept.length;
+    for (let step = 0; step < target; step += 1) {
+      const local = Math.min(draw.instanceCount - 1, Math.floor(step * stride));
+      kept.push(visibility.instances[draw.firstInstance + local]);
+    }
+    draws.push({
+      mesh: draw.mesh,
+      lod: draw.lod,
+      firstInstance,
+      instanceCount: kept.length - firstInstance,
+    });
+  }
+  return { instances: Uint32Array.from(kept), draws, visibleChunks: visibility.visibleChunks };
 }

--- a/src/graphics/quality.ts
+++ b/src/graphics/quality.ts
@@ -1,0 +1,140 @@
+/**
+ * Graphics quality presets.
+ *
+ * A single, self-contained settings module: the only persistent graphics
+ * preference the game has today. It is intentionally free of renderer / DOM
+ * imports so the lobby can read and store the choice without pulling in the
+ * WorldRenderer. The renderer consumes the resolved preset after launch.
+ */
+
+export type QualityLevel = 'low' | 'medium' | 'high' | 'ultra';
+
+export const QUALITY_LEVELS: readonly QualityLevel[] = ['low', 'medium', 'high', 'ultra'];
+
+/** Default on first run. Deliberately not ULTRA. */
+export const DEFAULT_QUALITY: QualityLevel = 'high';
+
+const STORAGE_KEY = 'ironfronts:graphics-quality';
+
+export interface QualityPreset {
+  /** Menu label. */
+  readonly label: string;
+  /** Sub-line shown under the selector. */
+  readonly blurb: string;
+  /**
+   * Backing-store scale relative to CSS pixels. Applied absolutely (see
+   * resolveRenderPixelRatio) so a 4K / retina panel never forces a 2x/3x
+   * buffer just because the device supports it.
+   */
+  readonly renderScale: number;
+  /** Multiplies every prop (tree / building / furniture) draw + LOD distance. */
+  readonly propDistanceScale: number;
+  /** Hard cap on visible tree instances submitted per frame. */
+  readonly treeInstanceBudget: number;
+  /** Hard cap on visible building instances submitted per frame. */
+  readonly buildingInstanceBudget: number;
+  /** Draw decorative road furniture (lamps, barriers, signs) at all. */
+  readonly furniture: boolean;
+  /** Multiplies the terrain chunk LOD switch distances (<1 = coarser sooner). */
+  readonly terrainLodScale: number;
+  /** Multiplies the viewport-derived rain particle count. */
+  readonly rainScale: number;
+  /**
+   * 0..1 detail signal handed to shaders via uniforms.weather.z. Lets shader
+   * work that is expensive but purely decorative (relief noise, extra water
+   * passes, AO) scale itself down without another uniform.
+   */
+  readonly detailFactor: number;
+}
+
+export const QUALITY_PRESETS: Record<QualityLevel, QualityPreset> = {
+  low: {
+    label: 'Low',
+    blurb: 'Best performance',
+    renderScale: 0.75,
+    propDistanceScale: 0.45,
+    treeInstanceBudget: 9_000,
+    buildingInstanceBudget: 6_000,
+    furniture: false,
+    terrainLodScale: 0.6,
+    rainScale: 0.35,
+    detailFactor: 0,
+  },
+  medium: {
+    label: 'Medium',
+    blurb: 'Balanced',
+    renderScale: 1,
+    propDistanceScale: 0.7,
+    treeInstanceBudget: 22_000,
+    buildingInstanceBudget: 14_000,
+    furniture: false,
+    terrainLodScale: 0.82,
+    rainScale: 0.6,
+    detailFactor: 0.4,
+  },
+  high: {
+    label: 'High',
+    blurb: 'High-quality strategic map',
+    renderScale: 1.25,
+    propDistanceScale: 1,
+    treeInstanceBudget: 60_000,
+    buildingInstanceBudget: 40_000,
+    furniture: true,
+    terrainLodScale: 1,
+    rainScale: 1,
+    detailFactor: 0.75,
+  },
+  ultra: {
+    label: 'Ultra',
+    blurb: 'Maximum world detail',
+    renderScale: 1.5,
+    propDistanceScale: 1.25,
+    treeInstanceBudget: 400_000,
+    buildingInstanceBudget: 400_000,
+    furniture: true,
+    terrainLodScale: 1.18,
+    rainScale: 1,
+    detailFactor: 1,
+  },
+};
+
+/**
+ * Backing-store pixel ratio for a preset. Absolute (× CSS pixels), independent
+ * of devicePixelRatio, clamped to [0.5, 1.5] so a HiDPI display never blows the
+ * buffer up to 2x/3x and a broken preset can never drop below 0.5x.
+ */
+export function resolveRenderPixelRatio(level: QualityLevel): number {
+  const target = QUALITY_PRESETS[level]?.renderScale ?? QUALITY_PRESETS[DEFAULT_QUALITY].renderScale;
+  return Math.max(0.5, Math.min(1.5, target));
+}
+
+export function isQualityLevel(value: unknown): value is QualityLevel {
+  return typeof value === 'string' && (QUALITY_LEVELS as readonly string[]).includes(value);
+}
+
+function safeStorage(explicit?: Storage): Storage | undefined {
+  if (explicit) return explicit;
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadQuality(storage?: Storage): QualityLevel {
+  try {
+    const raw = safeStorage(storage)?.getItem(STORAGE_KEY);
+    if (isQualityLevel(raw)) return raw;
+  } catch {
+    // Private mode / disabled storage: fall through to the default.
+  }
+  return DEFAULT_QUALITY;
+}
+
+export function saveQuality(level: QualityLevel, storage?: Storage): void {
+  try {
+    safeStorage(storage)?.setItem(STORAGE_KEY, level);
+  } catch {
+    // Nothing we can do; the in-memory choice still applies this session.
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import './styles.css';
 import '@fontsource/bitter/latin-ext-800.css';
 import '@fontsource/special-elite/latin-ext-400.css';
 import '@fontsource/cinzel-decorative/latin-ext-700.css';
+import { loadQuality } from './graphics/quality';
 import { mountMenu } from './menu/menu';
 import { WorldRenderer, type MapMode, type TimeOfDayState } from './renderer';
 import { parseClock } from './time-of-day';
@@ -61,6 +62,7 @@ const unsupported = required<HTMLElement>('unsupported');
 const compactNumber = new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 });
 
 let rendererStarted = false;
+let activeRenderer: WorldRenderer | undefined;
 mountMenu({
   onLaunch: () => {
     if (rendererStarted) return;
@@ -74,6 +76,8 @@ mountMenu({
       void start();
     }
   },
+  // In the lobby this only persists; once the renderer exists it applies live.
+  onGraphicsQuality: (level) => activeRenderer?.setQuality(level),
 });
 
 function startLoadingQuotes(): () => void {
@@ -97,7 +101,8 @@ function startLoadingQuotes(): () => void {
 
 async function start(): Promise<void> {
   const stopQuotes = startLoadingQuotes();
-  const renderer = new WorldRenderer(canvas, countryLabels);
+  const renderer = new WorldRenderer(canvas, countryLabels, loadQuality());
+  activeRenderer = renderer;
   window.addEventListener('pagehide', (event) => {
     if (!event.persisted) renderer.dispose();
   });
@@ -322,6 +327,9 @@ function updateDiagnostics(stats: FrameStats): void {
     `alt  ${stats.camera[2].toFixed(0).padStart(5)}   zoom ${stats.distance.toFixed(0)}`,
     `target    ${stats.targetProvince ?? 'water'} @ ${stats.targetElevation.toFixed(2)}`,
     `province  ${stats.hoveredProvince ?? '—'}`,
+    activeRenderer
+      ? `graphics  ${activeRenderer.graphicsQuality} @ ${activeRenderer.effectiveRenderScale.toFixed(2)}x  ${canvas.width}x${canvas.height}`
+      : 'graphics  —',
     `trees     ${stats.trees.toLocaleString()}`,
     `buildings ${stats.buildings.toLocaleString()}`,
     `roads     ${stats.emittedRoads.toLocaleString()} + ${stats.hiddenRoads} dotted`,

--- a/src/menu/menu.css
+++ b/src/menu/menu.css
@@ -232,6 +232,23 @@
 .ifm__row input[type="range"] { width: 9em; accent-color: var(--hud-gold); }
 .ifm__row input[type="checkbox"] { width: 1.1em; height: 1.1em; accent-color: var(--hud-gold); }
 
+/* Graphics-quality segmented control: label on top, four field buttons below. */
+.ifm__row--stack { grid-template-columns: 1fr; gap: .55em; cursor: default; }
+.ifm__row--stack:hover { border-left-color: transparent; background-image: linear-gradient(#332a1c, #1e1810), url('/menu/paper.jpg'); }
+.ifm__seg { display: grid; grid-template-columns: repeat(4, 1fr); gap: .4em; }
+.ifm__seg button {
+  padding: .5em .2em; border: 1px solid rgba(201,164,99,.28);
+  background: linear-gradient(#2b2317, #171207); background-blend-mode: multiply;
+  color: var(--hud-text-dim); cursor: pointer;
+  font: 700 .62em/1 var(--ifm-sans); letter-spacing: .12em; text-transform: uppercase;
+  transition: border-color .18s ease, color .18s ease, background .18s ease;
+}
+.ifm__seg button:hover { color: var(--hud-text); border-color: rgba(201,164,99,.5); }
+.ifm__seg button.is-selected {
+  color: var(--hud-gold-bright); border-color: var(--hud-gold-bright);
+  background: linear-gradient(#5a4522, #3a2c15);
+}
+
 /* operation rows (Campaign): OP-code + insignia + readiness dots */
 .ifm__row-code { display: block; margin-bottom: .3em; font: 700 .64em/1 var(--ifm-sans); letter-spacing: .1em; color: var(--hud-text-dim); opacity: .8; }
 .ifm__row-meta { display: flex; flex-direction: column; align-items: flex-end; gap: .5em; }

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -1,9 +1,18 @@
 import './menu.css';
 import { phase, runChoreo, smooth } from './choreo';
+import {
+  isQualityLevel, loadQuality, QUALITY_PRESETS, saveQuality, type QualityLevel,
+} from '../graphics/quality';
 
 export interface MenuHandlers {
   /** Called once the player commits to entering the world (campaign, continue, or sandbox). */
   onLaunch: () => void;
+  /**
+   * Fired when the player changes the graphics-quality preset in Settings.
+   * In the lobby this only persists the choice; once a WorldRenderer exists
+   * (after launch) main.ts forwards it to renderer.setQuality.
+   */
+  onGraphicsQuality?: (level: QualityLevel) => void;
 }
 
 const OPEN_DURATION = 1250;
@@ -132,6 +141,32 @@ export function mountMenu(handlers: MenuHandlers): void {
       if (row.dataset.objective) updateBriefing(row);
     });
   });
+
+  // Graphics quality selector. Reads/persists the choice locally and only
+  // notifies handlers - it never initializes the world renderer from the lobby.
+  const graphicsGroup = document.getElementById('ifm-graphics-quality');
+  const graphicsBlurb = document.getElementById('ifm-graphics-blurb');
+  if (graphicsGroup) {
+    const buttons = [...graphicsGroup.querySelectorAll<HTMLButtonElement>('[data-graphics-quality]')];
+    const paint = (level: QualityLevel): void => {
+      for (const button of buttons) {
+        const active = button.dataset.graphicsQuality === level;
+        button.setAttribute('aria-pressed', String(active));
+        button.classList.toggle('is-selected', active);
+      }
+      if (graphicsBlurb) graphicsBlurb.textContent = QUALITY_PRESETS[level].blurb;
+    };
+    paint(loadQuality());
+    for (const button of buttons) {
+      button.addEventListener('click', () => {
+        const level = button.dataset.graphicsQuality;
+        if (!isQualityLevel(level)) return;
+        saveQuality(level);
+        paint(level);
+        handlers.onGraphicsQuality?.(level);
+      });
+    }
+  }
 
   function launch(): void {
     root.style.transition = 'opacity .5s ease';

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,6 +1,10 @@
 import { vec3 } from 'gl-matrix';
 import { StrategyCamera } from './camera';
-import { buildPropVisibility, buildTerrainVisibility } from './chunk-visibility';
+import { buildPropVisibility, buildTerrainVisibility, capVisibleInstances } from './chunk-visibility';
+import {
+  DEFAULT_QUALITY, QUALITY_LEVELS, QUALITY_PRESETS, resolveRenderPixelRatio,
+  type QualityLevel, type QualityPreset,
+} from './graphics/quality';
 import { buildCountryColorBuffer, CountryLabelLayer } from './country-overlay';
 import { loadCountryLabelFont } from './country-labels/atlas';
 import { isValidCountryLabelPoint } from './country-labels/territory';
@@ -136,6 +140,7 @@ export class WorldRenderer {
   private frameHandle = 0;
   private previousTime = performance.now();
   private elapsed = 0;
+  private quality: QualityLevel = DEFAULT_QUALITY;
   private readonly environment = new EnvironmentController();
   private reportedClock = '';
   private performanceMonitor = new PerformanceMonitor(false);
@@ -181,9 +186,45 @@ export class WorldRenderer {
     console.error(`WebGPU validation error: ${message}`);
   };
 
-  constructor(canvas: HTMLCanvasElement, countryLabelCanvas?: HTMLCanvasElement) {
+  constructor(
+    canvas: HTMLCanvasElement,
+    countryLabelCanvas?: HTMLCanvasElement,
+    quality: QualityLevel = DEFAULT_QUALITY,
+  ) {
     this.canvas = canvas;
     this.countryLabelCanvas = countryLabelCanvas;
+    this.quality = QUALITY_PRESETS[quality] ? quality : DEFAULT_QUALITY;
+  }
+
+  private get qualityPreset(): QualityPreset {
+    return QUALITY_PRESETS[this.quality];
+  }
+
+  /** Current graphics preset id. */
+  get graphicsQuality(): QualityLevel {
+    return this.quality;
+  }
+
+  /** Backing-store scale actually in use (× CSS pixels). */
+  get effectiveRenderScale(): number {
+    return resolveRenderPixelRatio(this.quality);
+  }
+
+  /**
+   * Switch graphics preset at runtime. Triggers one safe resize /
+   * swap-chain + depth reconfigure and invalidates the visible-instance
+   * caches so the new draw distances and budgets take effect next frame.
+   * No GPU pipelines or world buffers are recreated.
+   */
+  setQuality(level: QualityLevel): void {
+    if (!QUALITY_PRESETS[level] || level === this.quality) return;
+    this.quality = level;
+    if (this.deviceReady) {
+      this.resize();
+      this.camera.revision += 1;
+      this.lastTerrainVisibilityRevision = -1;
+      this.performanceMonitor.reset();
+    }
   }
 
   async initialize(report: ProgressReporter): Promise<void> {
@@ -774,7 +815,11 @@ export class WorldRenderer {
   }
 
   private resize(): void {
-    const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+    // Backing-store scale is the graphics-quality preset (0.75 / 1.0 / 1.25 /
+    // 1.5), applied absolutely and capped at 1.5 so a 2x/3x HiDPI panel never
+    // forces an oversized buffer. devicePixelRatio is deliberately not a
+    // multiplier here.
+    const pixelRatio = resolveRenderPixelRatio(this.quality);
     const width = Math.max(1, Math.floor(this.canvas.clientWidth * pixelRatio));
     const height = Math.max(1, Math.floor(this.canvas.clientHeight * pixelRatio));
     if (this.canvas.width === width && this.canvas.height === height) return;
@@ -880,7 +925,15 @@ export class WorldRenderer {
       terrainInfo: [this.manifest.terrain.chunksX, this.manifest.terrain.chunksY, this.manifest.terrain.gridResolution, this.showWireframe ? 1 : 0],
       lighting: [lighting.daylight, lighting.twilight, lighting.night, this.environment.dayPhase],
       sky: [...skyColor, 0],
-      weather: [this.environment.rainIntensity, 0, 0, 0],
+      // weather.y = quality index (0 low .. 3 ultra), weather.z = 0..1 detail
+      // factor. Shaders can scale purely-decorative expensive work by these
+      // without a struct change.
+      weather: [
+        this.environment.rainIntensity,
+        QUALITY_LEVELS.indexOf(this.quality),
+        this.qualityPreset.detailFactor,
+        0,
+      ],
     });
     this.device.queue.writeBuffer(this.uniformBuffer, 0, values);
   }
@@ -954,16 +1007,20 @@ export class WorldRenderer {
 
     if (this.showProps) {
       pass.setPipeline(this.propPipeline);
+      // Graphics-quality scales prop draw + LOD distances down; low/medium
+      // drop decorative road furniture entirely.
+      const s = this.qualityPreset.propDistanceScale;
+      const d2 = (a: number, b: number): [number, number] => [a * s, b * s];
       if (this.performanceLayers.trees) {
-        this.drawPropChunks(pass, this.trees, this.manifest.propChunks.trees, this.treeMeshes, 'trees', 3_200, [900, 1_850]);
+        this.drawPropChunks(pass, this.trees, this.manifest.propChunks.trees, this.treeMeshes, 'trees', 3_200 * s, d2(900, 1_850));
       }
       if (this.performanceLayers.buildings) {
-        this.drawPropChunks(pass, this.buildings, this.manifest.propChunks.buildings, this.buildingMeshes, 'buildings', 2_600, [850, 1_650]);
+        this.drawPropChunks(pass, this.buildings, this.manifest.propChunks.buildings, this.buildingMeshes, 'buildings', 2_600 * s, d2(850, 1_650));
       }
-      if (this.performanceLayers.roadFurniture) {
-        this.drawPropChunks(pass, this.lamps, this.manifest.propChunks.lamps, [[this.lampMesh]], 'roadFurniture', 1_900, [1_900, 1_900]);
-        this.drawPropChunks(pass, this.barriers, this.manifest.propChunks.barriers, [[this.barrierMesh]], 'roadFurniture', 1_900, [1_900, 1_900]);
-        this.drawPropChunks(pass, this.signs, this.manifest.propChunks.signs, [[this.signMesh]], 'roadFurniture', 1_900, [1_900, 1_900]);
+      if (this.performanceLayers.roadFurniture && this.qualityPreset.furniture) {
+        this.drawPropChunks(pass, this.lamps, this.manifest.propChunks.lamps, [[this.lampMesh]], 'roadFurniture', 1_900 * s, d2(1_900, 1_900));
+        this.drawPropChunks(pass, this.barriers, this.manifest.propChunks.barriers, [[this.barrierMesh]], 'roadFurniture', 1_900 * s, d2(1_900, 1_900));
+        this.drawPropChunks(pass, this.signs, this.manifest.propChunks.signs, [[this.signMesh]], 'roadFurniture', 1_900 * s, d2(1_900, 1_900));
       }
       if (this.performanceLayers.buildings) this.drawCityLights(pass);
     }
@@ -1007,7 +1064,9 @@ export class WorldRenderer {
 
   private drawRain(pass: GPURenderPassEncoder): void {
     if (this.environment.rainIntensity < 0.005 || this.debugView !== 0) return;
-    const viewportParticles = Math.ceil(this.canvas.width * this.canvas.height / 2_200);
+    const viewportParticles = Math.ceil(
+      this.canvas.width * this.canvas.height / 2_200 * this.qualityPreset.rainScale,
+    );
     const particles = Math.min(MAX_RAIN_PARTICLES, Math.max(MIN_RAIN_PARTICLES, viewportParticles));
     pass.setPipeline(this.rainPipeline);
     pass.draw(6, particles);
@@ -1055,7 +1114,12 @@ export class WorldRenderer {
     const viewKey = String(category);
     const view = getVisibleInstanceView(this.device, this.instanceLayout, layer, viewKey, category);
     if (view.revision !== this.camera.revision) {
-      const visibility = buildPropVisibility(
+      const budget = category === 'trees'
+        ? this.qualityPreset.treeInstanceBudget
+        : category === 'buildings'
+          ? this.qualityPreset.buildingInstanceBudget
+          : Number.POSITIVE_INFINITY;
+      const visibility = capVisibleInstances(buildPropVisibility(
         this.manifest,
         ranges,
         groupMeshes,
@@ -1064,7 +1128,7 @@ export class WorldRenderer {
         maximumDistance,
         lodDistances,
         (centerX, centerZ, radius) => this.chunkIntersectsView(centerX, centerZ, radius),
-      );
+      ), budget);
       updateVisibleInstanceView(this.device.queue, view, this.camera.revision, visibility);
     }
     if (category === 'trees') this.frameWorkload.visibleChunks.trees += view.visibleChunks;
@@ -1109,6 +1173,7 @@ export class WorldRenderer {
       this.camera.position,
       (x, z) => this.sampleHeight(x, z),
       (centerX, centerZ, radius) => this.chunkIntersectsView(centerX, centerZ, radius),
+      this.qualityPreset.terrainLodScale,
     );
     this.terrainLodDraws = visibility.draws;
     if (visibility.instances.length) {

--- a/tests/graphics-quality.test.ts
+++ b/tests/graphics-quality.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { capVisibleInstances, type PropVisibility } from '../src/chunk-visibility';
+import type { Mesh } from '../src/scene-meshes';
+import {
+  DEFAULT_QUALITY, isQualityLevel, loadQuality, QUALITY_LEVELS, QUALITY_PRESETS,
+  resolveRenderPixelRatio, saveQuality,
+} from '../src/graphics/quality';
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() { return map.size; },
+    clear: () => map.clear(),
+    key: (i) => [...map.keys()][i] ?? null,
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k, v) => void map.set(k, String(v)),
+    removeItem: (k) => void map.delete(k),
+  };
+}
+
+describe('graphics quality presets', () => {
+  it('defines all four levels with ascending, capped render scales', () => {
+    expect(QUALITY_LEVELS).toEqual(['low', 'medium', 'high', 'ultra']);
+    const scales = QUALITY_LEVELS.map((level) => QUALITY_PRESETS[level].renderScale);
+    expect(scales).toEqual([0.75, 1, 1.25, 1.5]);
+    expect([...scales].sort((a, b) => a - b)).toEqual(scales);
+    expect(Math.max(...scales)).toBeLessThanOrEqual(1.5);
+  });
+
+  it('reduces real workload knobs monotonically from ultra to low', () => {
+    const treeBudgets = QUALITY_LEVELS.map((l) => QUALITY_PRESETS[l].treeInstanceBudget);
+    const propDist = QUALITY_LEVELS.map((l) => QUALITY_PRESETS[l].propDistanceScale);
+    const rain = QUALITY_LEVELS.map((l) => QUALITY_PRESETS[l].rainScale);
+    expect(treeBudgets[0]).toBeLessThan(treeBudgets[2]);
+    expect(propDist[0]).toBeLessThan(propDist[2]);
+    expect(rain[0]).toBeLessThan(rain[2]);
+    expect(QUALITY_PRESETS.low.furniture).toBe(false);
+    expect(QUALITY_PRESETS.high.furniture).toBe(true);
+  });
+
+  it('resolves an absolute pixel ratio clamped to [0.5, 1.5], ignoring devicePixelRatio', () => {
+    expect(resolveRenderPixelRatio('low')).toBe(0.75);
+    expect(resolveRenderPixelRatio('medium')).toBe(1);
+    expect(resolveRenderPixelRatio('high')).toBe(1.25);
+    expect(resolveRenderPixelRatio('ultra')).toBe(1.5);
+    for (const level of QUALITY_LEVELS) {
+      const ratio = resolveRenderPixelRatio(level);
+      expect(ratio).toBeGreaterThanOrEqual(0.5);
+      expect(ratio).toBeLessThanOrEqual(1.5);
+    }
+  });
+
+  it('persists and restores the choice, defaulting to HIGH and rejecting garbage', () => {
+    const storage = memoryStorage();
+    expect(loadQuality(storage)).toBe(DEFAULT_QUALITY);
+    expect(DEFAULT_QUALITY).toBe('high');
+    saveQuality('low', storage);
+    expect(loadQuality(storage)).toBe('low');
+    storage.setItem('ironfronts:graphics-quality', 'potato');
+    expect(loadQuality(storage)).toBe(DEFAULT_QUALITY);
+  });
+
+  it('validates level strings', () => {
+    expect(isQualityLevel('ultra')).toBe(true);
+    expect(isQualityLevel('LOW')).toBe(false);
+    expect(isQualityLevel(2)).toBe(false);
+  });
+});
+
+describe('capVisibleInstances', () => {
+  const mesh = {} as Mesh;
+  const build = (counts: number[]): PropVisibility => {
+    const instances: number[] = [];
+    const draws = counts.map((count, lod) => {
+      const firstInstance = instances.length;
+      for (let i = 0; i < count; i += 1) instances.push(firstInstance + i);
+      return { mesh, lod, firstInstance, instanceCount: count };
+    });
+    return { instances: Uint32Array.from(instances), draws, visibleChunks: counts.length };
+  };
+
+  it('returns the same object when already within budget', () => {
+    const vis = build([50, 30]);
+    expect(capVisibleInstances(vis, 100)).toBe(vis);
+    expect(capVisibleInstances(vis, Number.POSITIVE_INFINITY)).toBe(vis);
+  });
+
+  it('thins every draw proportionally when over budget', () => {
+    const vis = build([600, 400]); // 1000 total
+    const capped = capVisibleInstances(vis, 250);
+    expect(capped.instances.length).toBeLessThanOrEqual(260);
+    expect(capped.instances.length).toBeGreaterThan(200);
+    // both LOD draws survive, contiguous, in the same order
+    expect(capped.draws).toHaveLength(2);
+    expect(capped.draws[0].firstInstance).toBe(0);
+    expect(capped.draws[1].firstInstance).toBe(capped.draws[0].instanceCount);
+    expect(capped.draws[0].instanceCount).toBeGreaterThan(capped.draws[1].instanceCount);
+    // kept indices are a strided subset of the originals (still ascending)
+    const kept = [...capped.instances];
+    expect([...kept].sort((a, b) => a - b)).not.toEqual(kept.slice().reverse());
+    expect(new Set(kept).size).toBe(kept.length);
+  });
+});


### PR DESCRIPTION
A real, persistent Graphics Quality setting in the existing Settings dossier. Default **High**; never Ultra. Affects actual renderer workload, not CSS.

## What it changes per level

| | render scale | trees | buildings | road furniture | terrain LOD | rain particles | detail signal to shaders |
|---|---|---|---|---|---|---|---|
| **Low** | 0.75 | budget 9k, draw dist ×0.45 | budget 6k, ×0.45 | **off** | ×0.6 (coarser sooner) | ×0.35 | 0.0 |
| **Medium** | 1.0 | budget 22k, ×0.7 | budget 14k, ×0.7 | **off** | ×0.82 | ×0.6 | 0.4 |
| **High** | 1.25 | budget 60k, ×1.0 | budget 40k, ×1.0 | on | ×1.0 | ×1.0 | 0.75 |
| **Ultra** | 1.5 | budget 400k, ×1.25 | budget 400k, ×1.25 | on | ×1.18 | ×1.0 | 1.0 |

Every knob is **real submitted-work reduction**, not draw-then-hide:
- **Render scale** — absolute backing-store ratio, clamped `[0.5, 1.5]`. `devicePixelRatio` is **not** a multiplier, so a 2×/3× panel never forces an oversized buffer.
- **Instance budgets** — `capVisibleInstances()` (new, in `chunk-visibility.ts`) stride-samples the culled prop set down to the budget *before* it is uploaded. Fewer instances submitted.
- **Draw / LOD distances** — prop and terrain-chunk LOD switch distances scaled per preset; fewer chunks pass the cull, coarser terrain meshes sooner.
- **Road furniture** (lamps/barriers/signs) skipped entirely on Low/Medium.
- **Rain** — viewport-derived particle count scaled.
- `uniforms.weather.y` / `.z` now carry the quality index + a 0–1 detail factor so shader work that is expensive-but-decorative (relief noise, extra water passes) can scale itself down later.

## Persistence & UI

- `src/graphics/quality.ts` — the preset table + `localStorage` load/save (`ironfronts:graphics-quality`), storage-safe (private mode falls back to the default). This is the game's first settings-persistence module; when the audio branch's `audio-preferences.ts` lands the two can be unified.
- Settings dossier gains a war-room-styled `GRAPHICS QUALITY  [Low][Medium][High][Ultra]` segmented control with a live sub-line ("Best performance" … "Maximum world detail").
- Diagnostics (F3) shows `graphics <level> @ <scale>x <w>x<h>`.

## Lobby safety (menu crashes)

The selector **never touches `WorldRenderer` from the lobby** — it only persists and fires `onGraphicsQuality`. `main.ts` passes `loadQuality()` into the renderer *at launch only* (after Begin Operation) and forwards later changes to `renderer.setQuality`. All the existing crash-resistance (compositor-only dossier, no hover audio unlock, deferred renderer) is untouched. No per-frame / FPS-driven resize — `setQuality` does exactly one safe `resize()` + swap-chain/depth reconfigure and invalidates the visible-instance caches; no pipelines or world buffers are recreated.

## Tests

`npm run build:world` ✅ · `npm run check` ✅ (12 files, 69 tests). New `tests/graphics-quality.test.ts` covers the preset table, the pixel-ratio clamp, persistence + garbage rejection, and `capVisibleInstances` (budget respected, per-draw proportional thinning, no-op under budget).

## Overlaps / merge note

- **Supersedes #36** — replaces the same one line in `renderer.ts resize()`. Recommend closing #36, or merging it first and dropping the duplicate line here (~3-line conflict). See `docs/PR_MERGE_PLAN.md`.
- Merges clean with #29–#42 otherwise (menu.ts/.css auto-merge with #29).
- After #35 lands, the shader city-LOD *count* reduction should defer to this branch's instance budget; #35 keeps its per-building height/footprint shrink.

Also adds `docs/BRANCH_STATUS.md` and `docs/PR_MERGE_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)