### PR TITLE
Fix audio recovery after browser refresh

### DIFF
--- a/src/audio/audio-manager.ts
+++ b/src/audio/audio-manager.ts
@@ -119,10 +119,9 @@ export class AudioManager {
   }
 
   /**
-   * Warm the first-interaction audio path while the menu is idle. Browsers
-   * still require a user gesture before playback, but fetching/decoding can
-   * happen beforehand so the first legitimate pointer/keyboard gesture does
-   * not also pay the network/decode cost.
+   * Warm the lobby soundtrack path while the menu is idle. Browsers still
+   * require a user gesture before Web Audio playback, so UI sample decoding
+   * stays lazy and AudioContext creation remains gesture-gated.
    */
   prime(musicUrls: readonly string[] = []): void {
     // Lobby music gets first claim on bandwidth.

--- a/src/audio/audio-manager.ts
+++ b/src/audio/audio-manager.ts
@@ -77,7 +77,11 @@ export class AudioManager {
   }
 
   isMusicPlaying(): boolean {
-    return Boolean(this.currentMusic && !this.currentMusic.element.paused);
+    return Boolean(
+      this.context?.state === 'running'
+      && this.currentMusic
+      && !this.currentMusic.element.paused,
+    );
   }
 
   setVolume(bus: AudioBus, value: number): number {
@@ -121,13 +125,14 @@ export class AudioManager {
    * not also pay the network/decode cost.
    */
   prime(musicUrls: readonly string[] = []): void {
-    // Lobby music gets first claim on bandwidth. The two large paper samples
-    // are intentionally left lazy so they cannot delay the first soundtrack.
+    // Lobby music gets first claim on bandwidth.
     for (const url of musicUrls) this.prepareMusic(url);
-    for (const cue of ['hover', 'confirm', 'back'] as const) {
-      const url = UI_SAMPLE_URLS[cue];
-      if (url) void this.loadBuffer(url);
-    }
+
+    // Keep Web Audio creation strictly behind a real user gesture. loadBuffer()
+    // calls ensureContext(), and creating an AudioContext while the document is
+    // loading can leave Chrome with a suspended context after refresh. UI
+    // samples are small enough to decode lazily on the first activated click.
+    // This also makes the first soundtrack/SFX recovery path deterministic.
   }
 
   prepareMusic(url: string): void {
@@ -364,7 +369,9 @@ export class AudioManager {
       if (targetDocument.hidden) {
         void context.suspend().catch(() => undefined);
       } else {
-        void context.resume().catch(() => undefined);
+        void context.resume()
+          .then(() => { this.unlocked = context.state === 'running'; })
+          .catch(() => { this.unlocked = false; });
       }
     };
     targetDocument.addEventListener('visibilitychange', onVisibilityChange);

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,18 +149,36 @@ audio.prime(firstMenuTrack ? trackSources(firstMenuTrack).slice(0, 1) : []);
 audio.installLifecycle();
 
 // Try to start the lobby soundtrack immediately when the page opens. Browsers
-// may still block audible autoplay, so the first user gesture retries only if
-// playback did not actually begin.
+// are allowed to block audible autoplay after a navigation/refresh, so a real
+// user gesture owns AudioContext activation. Keep the recovery listeners
+// available instead of consuming them after one attempt: Chrome can reject an
+// early resume (or re-suspend audio after a tab visibility change).
 void music.setState('menu');
 
-let autoplayRetryDone = false;
-const retryMenuMusicAfterAutoplayBlock = (): void => {
-  if (autoplayRetryDone || audio.isMusicPlaying()) return;
-  autoplayRetryDone = true;
-  void music.setState('menu', { force: true });
+let menuMusicHasPlayed = false;
+let audioGestureRecoveryInFlight = false;
+const recoverAudioAfterGesture = (): void => {
+  if (audioGestureRecoveryInFlight) return;
+  audioGestureRecoveryInFlight = true;
+  void (async () => {
+    try {
+      if (!await audio.unlock()) return;
+
+      // The initial autoplay attempt may have left the director in "menu"
+      // state even though no track actually started. Retry only until menu
+      // music has successfully played once; normal director gaps afterwards
+      // must remain intentional.
+      if (!menuMusicHasPlayed && music.getState() === 'menu' && !audio.isMusicPlaying()) {
+        await music.setState('menu', { force: true });
+      }
+      if (audio.isMusicPlaying()) menuMusicHasPlayed = true;
+    } finally {
+      audioGestureRecoveryInFlight = false;
+    }
+  })();
 };
-document.addEventListener('pointerdown', retryMenuMusicAfterAutoplayBlock, { capture: true, once: true });
-document.addEventListener('keydown', retryMenuMusicAfterAutoplayBlock, { capture: true, once: true });
+document.addEventListener('pointerdown', recoverAudioAfterGesture, { capture: true });
+document.addEventListener('keydown', recoverAudioAfterGesture, { capture: true });
 
 window.addEventListener('pagehide', (event) => {
   if (!event.persisted) {

--- a/tests/lobby-startup.test.ts
+++ b/tests/lobby-startup.test.ts
@@ -28,4 +28,16 @@ describe('lightweight lobby startup', () => {
     expect(prepareMusic).toContain("fetch(url, { cache: 'force-cache' })");
     expect(prepareMusic).not.toContain('new Audio()');
   });
+
+  it('does not create a Web Audio context while merely priming the lobby', () => {
+    const audio = readFileSync(path.join(root, 'src/audio/audio-manager.ts'), 'utf8');
+    const start = audio.indexOf('prime(musicUrls: readonly string[] = [])');
+    const end = audio.indexOf('prepareMusic(url: string)', start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const prime = audio.slice(start, end);
+    expect(prime).toContain('this.prepareMusic(url)');
+    expect(prime).not.toContain('this.loadBuffer(');
+    expect(prime).not.toContain('this.ensureContext(');
+  });
 });

--- a/tests/menu-interaction-stability.test.ts
+++ b/tests/menu-interaction-stability.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 const root = process.cwd();
 const menu = readFileSync(path.join(root, 'src/menu/menu.ts'), 'utf8');
 const audio = readFileSync(path.join(root, 'src/audio/audio-manager.ts'), 'utf8');
+const main = readFileSync(path.join(root, 'src/main.ts'), 'utf8');
 
 describe('menu interaction stability', () => {
   it('keeps dossier animation compositor-only', () => {
@@ -28,5 +29,20 @@ describe('menu interaction stability', () => {
 
   it('does not activate audio from passive hover before unlock', () => {
     expect(audio).toContain("if (cue === 'hover' && !this.unlocked) return");
+  });
+
+  it('keeps refresh audio recovery available until a real activation succeeds', () => {
+    expect(main).toContain("document.addEventListener('pointerdown', recoverAudioAfterGesture, { capture: true })");
+    expect(main).toContain("document.addEventListener('keydown', recoverAudioAfterGesture, { capture: true })");
+    expect(main).not.toContain("recoverAudioAfterGesture, { capture: true, once: true }");
+    expect(main).toContain("if (!await audio.unlock()) return");
+    expect(main).toContain("await music.setState('menu', { force: true })");
+  });
+
+  it('does not report music as audible while its AudioContext is suspended', () => {
+    const start = audio.indexOf('isMusicPlaying(): boolean');
+    const end = audio.indexOf('setVolume(', start);
+    const method = audio.slice(start, end);
+    expect(method).toContain("this.context?.state === 'running'");
   });
 });


### PR DESCRIPTION
## What this fixes

Chrome/Edge may suspend/block Web Audio after a page refresh. The current lobby also creates an AudioContext while merely priming UI audio, then consumes its autoplay-retry listener after a single gesture even if recovery failed.

This PR keeps Web Audio creation behind a real user gesture and makes refresh recovery repeatable until menu music has actually started.

### Changes
- do not create/decode Web Audio UI buffers during lobby priming
- treat music as playing only while the AudioContext is actually running
- update the cached unlock state after visibility resume attempts
- keep pointer/keyboard audio recovery available instead of `once: true`
- retry the blocked menu soundtrack only until it has successfully played once
- add regression/source-contract tests for refresh-safe audio startup

### Expected browser behavior
A browser may still legally block sound immediately on refresh. The first real click/key interaction should now reliably unlock audio, start the menu soundtrack, and allow UI SFX instead of leaving the session silent.

### Validation
Changes were reviewed against the current audio startup path and regression tests were added. I could not execute the repository test suite from this environment, so local `npm run check` plus a real Chrome refresh/click smoke test are still required before merge.